### PR TITLE
Rename review-code plugin to deep-review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,10 @@
   },
   "plugins": [
     {
-      "name": "review-code",
+      "name": "deep-review",
       "description": "Rigorous code review of all changes on the current branch compared to main, with structured verdict and actionable feedback",
       "author": { "name": "Tim Zander" },
-      "source": "./plugins/review-code",
+      "source": "./plugins/deep-review",
       "category": "productivity",
       "strict": false
     },

--- a/plugins/deep-review/.claude-plugin/plugin.json
+++ b/plugins/deep-review/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "review-code",
+  "name": "deep-review",
   "description": "Rigorous code review of all changes on the current branch compared to main, with structured verdict and actionable feedback",
   "author": {
     "name": "Tim Zander"

--- a/plugins/deep-review/README.md
+++ b/plugins/deep-review/README.md
@@ -1,11 +1,18 @@
-# review-code
+# deep-review
 
 Rigorous code review plugin that reviews all changes on the current branch compared to main.
+
+> **Renamed from `review-code`** to avoid conflict with Claude's built-in `/review` skill.
+> If you have `review-code` installed, uninstall it and install `deep-review`:
+> ```
+> /plugin uninstall review-code
+> /plugin install deep-review@tzander-skills
+> ```
 
 ## Usage
 
 ```
-/review-code
+/deep-review
 ```
 
 ## What It Does

--- a/plugins/deep-review/commands/deep-review.md
+++ b/plugins/deep-review/commands/deep-review.md
@@ -1,5 +1,5 @@
 ---
-name: review-code
+name: deep-review
 description: Perform a critical code review of all changes on the current branch compared to main
 disable-model-invocation: true
 allowed-tools: Bash, Read, Grep, Glob
@@ -11,7 +11,7 @@ You are a ruthless code reviewer performing deep analysis of every change on the
 
 **Your mandate:** Find every problem. Do not be agreeable. Do not give the benefit of the doubt. Do not hand-wave past code that "looks fine." If you cannot explain exactly why a line is correct, treat it as suspicious. If you find nothing, re-read the diff once more to be sure — but a genuinely clean change deserves a clean review.
 
-<!-- Keep these principles in sync with standards/CLAUDE.md "Code Review Standards" -->
+<!-- Keep in sync with standards/CLAUDE.md "Code Review Standards" -->
 **Non-negotiable principles:**
 - Assume there are bugs until you have proven otherwise by reading every line.
 - Absence is a defect. Missing error handling, missing tests, missing edge cases, missing logging — all are findings.

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -40,7 +40,7 @@ then have each developer re-run the sync script.
 - Include at least one negative test (invalid input, failure scenario) per method under test
 - Tests should verify observable behavior, not implementation details
 
-<!-- Keep in sync with plugins/review-code/commands/review-code.md preamble -->
+<!-- Keep in sync with plugins/deep-review/commands/deep-review.md preamble -->
 ## Code Review Standards
 
 When reviewing code (PRs, branches, or staged changes), apply rigorous scrutiny. The goal is to catch problems before they ship, not to be agreeable.


### PR DESCRIPTION
Closes #2

## Summary

- Renames `review-code` plugin to `deep-review` to avoid autocomplete conflict with Claude's built-in `/review` skill
- Updates all references: directory, command file, plugin.json, marketplace.json, and standards sync comment
- Adds migration instructions to README for existing users

## Test plan

- [ ] `/plugin install deep-review@tzander-skills` installs successfully
- [ ] `/deep-review` invokes the skill correctly
- [ ] `review-code` no longer appears in the marketplace listing