### PR TITLE
Add git push safety guardrails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,13 @@ az devops invoke --area tfvc --resource items \
 
 Replace `<PROJECT>`, `<TFVC_ROOT>`, and `<ORG_URL>` with values from your private `~/.claude/CLAUDE.md`.
 
+## Git Push Safety
+
+These rules apply to all plugin commands and manual operations:
+
+- **Never push to `main` or `master`** — all changes must go through pull requests
+- **Never force push** (`--force`, `-f`, `--force-with-lease`) to any branch
+
 ## Testing
 
 1. Register: `/plugin marketplace add TimZander/claude`

--- a/plugins/craft-commit-push/commands/craft-commit-push.md
+++ b/plugins/craft-commit-push/commands/craft-commit-push.md
@@ -14,6 +14,9 @@ You are crafting a commit message for the currently staged changes and producing
 1. Run `git diff --cached --stat` to see which files are staged.
 2. Run `git diff --cached -U5` to see the full staged diff with context.
 3. Run `echo "OS=$(uname -s)"` to detect the user's operating system.
+4. Run `git branch --show-current` to check the current branch.
+
+**If the current branch is `main` or `master`, stop immediately and tell the user: "You are on `<branch>`. All changes must go through a pull request — switch to a feature branch first."**
 
 If there are no staged changes, stop immediately and tell the user: "No staged changes found. Stage your changes with `git add` first."
 
@@ -99,5 +102,7 @@ Then tell the user the command has been copied to their clipboard and they can p
 Also display the command in your response for reference, but note that the clipboard copy is the reliable way to use it.
 
 **Do NOT run the git commit or git push commands.** Only copy the command to the clipboard and display it.
+
+**Never include `--force`, `-f`, or `--force-with-lease` in the push command.**
 
 **Do NOT add a `Co-Authored-By` trailer or any other attribution line.** The commit message must contain only the subject and optional body — nothing else.

--- a/plugins/craft-pr/scripts/create-pr.sh
+++ b/plugins/craft-pr/scripts/create-pr.sh
@@ -81,6 +81,13 @@ if [[ -z "$BRANCH" ]]; then
     exit 1
 fi
 
+# ── Branch safety ────────────────────────────────────────────────────
+
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+    echo "Error: Refusing to push to '$BRANCH'. Create a feature branch first." >&2
+    exit 1
+fi
+
 # ── Pre-flight checks ───────────────────────────────────────────────
 
 if [[ "$PLATFORM" == "github" ]]; then

--- a/plugins/craft-stage-commit-push/commands/craft-stage-commit-push.md
+++ b/plugins/craft-stage-commit-push/commands/craft-stage-commit-push.md
@@ -20,6 +20,9 @@ You are crafting a single command that stages meaningful files, commits, and pus
 4. Run `git diff -U5` to see the full unstaged diff with context.
 5. Run `git diff --cached -U5` to see the full staged diff with context.
 6. Run `echo "OS=$(uname -s)"` to detect the user's operating system.
+7. Run `git branch --show-current` to check the current branch.
+
+**If the current branch is `main` or `master`, stop immediately and tell the user: "You are on `<branch>`. All changes must go through a pull request — switch to a feature branch first."**
 
 If there are no unstaged changes, no untracked files, and no staged changes, stop immediately and tell the user: "No changes found. There is nothing to stage or commit."
 
@@ -147,5 +150,7 @@ Then tell the user the command has been copied to their clipboard and they can p
 Also display the command in your response for reference, but note that the clipboard copy is the reliable way to use it.
 
 **Do NOT run the git add, git commit, or git push commands.** Only copy the command to the clipboard and display it.
+
+**Never include `--force`, `-f`, or `--force-with-lease` in the push command.**
 
 **Do NOT add a `Co-Authored-By` trailer or any other attribution line.** The commit message must contain only the subject and optional body — nothing else.

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -40,6 +40,11 @@ then have each developer re-run the sync script.
 - Include at least one negative test (invalid input, failure scenario) per method under test
 - Tests should verify observable behavior, not implementation details
 
+## Git Push Safety
+
+- **Never push to `main` or `master`** — all changes must go through pull requests
+- **Never force push** (`--force`, `-f`, `--force-with-lease`) to any branch
+
 <!-- Keep in sync with plugins/deep-review/commands/deep-review.md preamble -->
 ## Code Review Standards
 


### PR DESCRIPTION
## Summary

Adds guardrails to prevent pushing directly to main/master and block force-push flags across all push-capable surfaces in the repository.

## Changes

- Add "Git Push Safety" section to `CLAUDE.md` and `standards/CLAUDE.md` documenting the rules
- Add branch check (main/master) to `craft-commit-push` and `craft-stage-commit-push` plugin commands — stops immediately if on a protected branch
- Add force-push prohibition (`--force`, `-f`, `--force-with-lease`) to both push-capable plugin commands
- Add shell-level branch guard to `craft-pr/scripts/create-pr.sh` before any network calls

## Gotchas

None identified.

## Test Cases

- [ ] Run `craft-commit-push` on main — should refuse with a clear message
- [ ] Run `craft-stage-commit-push` on main — should refuse with a clear message
- [ ] Run `craft-pr --create` on main — should refuse via `create-pr.sh`
- [ ] Run all three commands on a feature branch — should work normally