### PR TITLE
Fix har-investigate script path resolution

### DIFF
--- a/plugins/har-investigate/agents/har-investigate.md
+++ b/plugins/har-investigate/agents/har-investigate.md
@@ -15,7 +15,7 @@ Identify the `.har` file path from the user's message. If the path is relative, 
 
 Find the bundled parser script using Glob with the pattern `**/har-investigate/**/har_parse.py` rooted at the user's home directory `~/.claude/plugins` (resolve `~` to an absolute path before calling Glob).
 
-If no results are returned, tell the user the har-investigate plugin may not be installed correctly and stop. If multiple results are returned, exclude any path containing a sibling `.orphaned_at` file (check with Read) and use the remaining one.
+If no results are returned, tell the user the har-investigate plugin may not be installed correctly and stop. If multiple results are returned, for each result check whether a `.orphaned_at` file exists in the version directory (the parent of `scripts/` — e.g. if the result is `…/<hash>/scripts/har_parse.py`, check `…/<hash>/.orphaned_at` using Read). Exclude any path where that file exists. If zero results remain after filtering, tell the user the plugin may need reinstalling and stop. If multiple remain, use the first result (Glob returns results sorted by most recently modified).
 
 Run the script:
 


### PR DESCRIPTION
## Summary

- Glob defaults to project CWD, so the agent couldn't find the bundled `har_parse.py` under `~/.claude/plugins/`
- Updated the agent prompt to specify `~/.claude/plugins` as the Glob path

## Test plan

- [ ] Install plugin and trigger with a `.har` file
- [ ] Verify the agent locates and runs `har_parse.py` without errors