### PR TITLE
Add Bash permission warning to har-investigate agent

### DIFF
--- a/plugins/har-investigate/agents/har-investigate.md
+++ b/plugins/har-investigate/agents/har-investigate.md
@@ -17,6 +17,8 @@ Find the bundled parser script using Glob with the pattern `**/har-investigate/*
 
 If no results are returned, tell the user the har-investigate plugin may not be installed correctly and stop. If multiple results are returned, for each result check whether a `.orphaned_at` file exists in the version directory (the parent of `scripts/` — e.g. if the result is `…/<hash>/scripts/har_parse.py`, check `…/<hash>/.orphaned_at` using Read). Exclude any path where that file exists. If zero results remain after filtering, tell the user the plugin may need reinstalling and stop. If multiple remain, use the first result (Glob returns results sorted by most recently modified).
 
+Before running the script, tell the user: "I need to run the bundled HAR parser script. You may be prompted to approve Bash access — this runs the plugin's own `har_parse.py`, not arbitrary code."
+
 Run the script:
 
 ```bash


### PR DESCRIPTION
## Summary
- Agents don't auto-approve `allowed-tools: Bash` like commands do, so users get a permission prompt when the HAR parser script runs
- Add a warning message in the agent instructions so it tells the user what's happening before the Bash prompt appears

## Test plan
- [ ] Install the updated plugin on a machine: `/plugin install har-investigate@tzander-skills`
- [ ] Trigger the agent by mentioning a `.har` file
- [ ] Verify the agent warns about the Bash permission before running the script
- [ ] Approve the Bash prompt and verify the agent proceeds normally
- [ ] Check whether a second Bash call in the same conversation prompts again or is auto-approved