### PR TITLE
Convert har-investigate from agent to command

### DIFF
--- a/plugins/har-investigate/commands/har-investigate.md
+++ b/plugins/har-investigate/commands/har-investigate.md
@@ -63,7 +63,7 @@ If no focus was given, provide a high-level summary of the API surface and then 
 ## Rules
 
 - **Only use the bundled `har_parse.py` script.** Never write or execute ad hoc Python code.
-- **Only read the HAR file specified by the user.** Do not read other files unless the user asks.
+- **Only read the HAR file identified in Step 1.** Do not read other files unless the user asks.
 - When no focus area is given, lead with the dependency chain and call ordering — that's the most valuable insight for reverse engineering.
 - If the output is very large, summarize the high-level flow first, then offer to detail specific endpoints.
 - When the user asks follow-up questions, refer back to the script output rather than re-running it.


### PR DESCRIPTION
## Summary
- Agents don't auto-approve `allowed-tools` and have unreliable auto-triggering
- Converting to a command gives reliable `/har-investigate` invocation with auto-approved Bash, Read, and Glob access
- Removes the Bash permission warning added in #14 (no longer needed since commands auto-approve)

## Test plan
- [ ] Install the plugin: `/plugin install har-investigate@tzander-skills`
- [ ] Verify `/har-investigate` appears in command list
- [ ] Run `/har-investigate <har-file-path>` and confirm no permission prompts
- [ ] Verify the bundled `har_parse.py` is found and executed successfully