### PR TITLE
Show added/removed lines in sync-standards output

### DIFF
--- a/sync-standards.ps1
+++ b/sync-standards.ps1
@@ -49,12 +49,33 @@ else {
     if ($ExistingContent -match [regex]::Escape($StartMarker)) {
         # Markers exist — replace the managed section in-place
         $Pattern = [regex]::Escape($StartMarker) + '[\s\S]*?' + [regex]::Escape($EndMarker)
+
+        # Extract old managed section content (between markers, exclusive)
+        $OldSectionPattern = [regex]::Escape($StartMarker) + '\r?\n([\s\S]*?)\r?\n' + [regex]::Escape($EndMarker)
+        $OldSection = [regex]::Match($ExistingContent, $OldSectionPattern).Groups[1].Value
+
         $UpdatedContent = [regex]::Replace($ExistingContent, $Pattern, $ManagedSection)
 
         if ($UpdatedContent -eq $ExistingContent) {
             Write-Host "Team standards in $TargetFile are already up to date."
         }
         else {
+            # Show what changed
+            $OldLines = $OldSection -split '\r?\n'
+            $NewLines = $StandardsContent.TrimEnd() -split '\r?\n'
+            $Diff = Compare-Object -ReferenceObject $OldLines -DifferenceObject $NewLines
+            if ($Diff) {
+                Write-Host "Changes:"
+                foreach ($d in $Diff) {
+                    if ($d.SideIndicator -eq '=>') {
+                        Write-Host "  + $($d.InputObject)"
+                    }
+                    else {
+                        Write-Host "  - $($d.InputObject)"
+                    }
+                }
+            }
+
             Set-Content -Path $TargetFile -Value $UpdatedContent -NoNewline
             Write-Host "Updated team standards in $TargetFile."
         }

--- a/sync-standards.sh
+++ b/sync-standards.sh
@@ -40,6 +40,14 @@ elif grep -qF "$START_MARKER" "$TARGET_FILE"; then
     # Markers exist — replace the managed section in-place
     EXISTING_CONTENT="$(cat "$TARGET_FILE")"
 
+    # Extract old managed section content (between markers, exclusive)
+    OLD_SECTION_FILE="$(mktemp)"
+    awk -v start="$START_MARKER" -v end="$END_MARKER" '
+        $0 == start { capture=1; next }
+        $0 == end { capture=0; next }
+        capture { print }
+    ' "$TARGET_FILE" > "$OLD_SECTION_FILE"
+
     # Use awk to replace everything between (and including) the markers.
     # Write the managed section to a temp file because awk -v cannot handle
     # multi-line strings (causes "newline in string" errors).
@@ -55,9 +63,20 @@ elif grep -qF "$START_MARKER" "$TARGET_FILE"; then
     if [ "$UPDATED_CONTENT" = "$EXISTING_CONTENT" ]; then
         echo "Team standards in $TARGET_FILE are already up to date."
     else
+        # Show what changed
+        NEW_SECTION_FILE="$(mktemp)"
+        printf '%s\n' "$STANDARDS_CONTENT" > "$NEW_SECTION_FILE"
+        echo "Changes:"
+        diff "$OLD_SECTION_FILE" "$NEW_SECTION_FILE" \
+            --old-line-format='  - %L' \
+            --new-line-format='  + %L' \
+            --unchanged-line-format='' || true
+        rm -f "$NEW_SECTION_FILE"
+
         printf '%s' "$UPDATED_CONTENT" > "$TARGET_FILE"
         echo "Updated team standards in $TARGET_FILE."
     fi
+    rm -f "$OLD_SECTION_FILE"
 else
     # No markers — append the managed section
     # Add appropriate spacing


### PR DESCRIPTION
## Summary
- When `sync-standards` updates the managed section in `~/.claude/CLAUDE.md`, the scripts now display a line-by-line diff showing exactly which lines were added and removed
- Applies to both the PowerShell (`sync-standards.ps1`) and Bash (`sync-standards.sh`) variants

## Test plan
- [x] Run `sync-standards.ps1` when standards are already up to date — confirm "already up to date" message, no diff
- [x] Modify `standards/CLAUDE.md`, then run `sync-standards.ps1` — confirm diff output shows added/removed lines
- [ ] Repeat both scenarios with `sync-standards.sh` on a Unix shell