### PR TITLE
Optimize story fetch and preserve images

### DIFF
--- a/plugins/improve-stories/commands/improve-stories.md
+++ b/plugins/improve-stories/commands/improve-stories.md
@@ -218,6 +218,7 @@ Before updating each story, verify:
 ### 4e: Update the Work Items
 
 - If the story already has description content, incorporate any relevant context from the original into the new structured description. Do not silently discard product owner notes, links, stakeholder references, or edge case mentions — weave them into the appropriate section of the template.
+- **Preserve all images and attachments.** Scan the original HTML for `<img>` tags (typically pointing to `_apis/wit/attachments/...`). These are screenshots, mockups, or reference images added by the author. Include them in the new description — either inline in the relevant section or in a dedicated "Reference Images" section at the end. Never drop `<img>` tags during a rewrite.
 - Write the updated description to each ADO work item using the update tool.
 - After each successful update, add a brief work item comment noting what was changed (e.g., "Description restructured — added root cause analysis, acceptance criteria, and proposed fix based on codebase research."). This creates an audit trail so reviewers know the description was reworked.
 - Do NOT change title, state, assignment, or story points.


### PR DESCRIPTION
## Summary
- Two-phase fetch: lightweight fields first (title, state, type, area) for filtering/triage, then full descriptions only for candidates that survive — reduces MCP payload from ~12k tokens to ~2-3k for typical iterations
- Preserve images and attachments (`<img>` tags) during description rewrites — previously these were silently dropped
- Restore audit trail comments after each work item update, with `wit_add_work_item_comment` added to allowed-tools

## Test plan
- [ ] Run `/improve-stories` on an iteration with 20+ items — verify the initial fetch is lightweight (no descriptions) and full details are only fetched for candidates
- [ ] Run on a work item with embedded screenshots — verify images appear in the updated description
- [ ] Verify a work item comment is added after each successful update