### PR TITLE
Add phased work guideline to shared standards

### DIFF
--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -53,6 +53,10 @@ then have each developer re-run the sync script.
 
 When asked to push a branch or create a pull request, remind the user to run `/deep-review` on the current branch if they haven't already done so during this session. Keep the reminder to a single sentence — do not block the push or PR.
 
+## Phased Work
+
+When an issue defines phased work (Phase 1, Phase 2, Phase 3), ship each phase as a separate PR — even when the phases feel small. Interaction bugs between phases (e.g., a new tri-state return value meeting existing binary assumptions in callers) only surface when the phases are integrated. Separate PRs catch these incrementally during review instead of requiring multiple fix-up commits after the fact.
+
 <!-- Keep in sync with plugins/deep-review/commands/deep-review.md preamble -->
 ## Code Review Standards
 


### PR DESCRIPTION
## Summary

- Adds a "Phased Work" section to `standards/CLAUDE.md` requiring each phase of multi-phase issues to ship as a separate PR
- Catches cross-phase interaction bugs incrementally during review instead of bundling them into fix-up commits

Closes #30

## Test plan

- [ ] Verify `standards/CLAUDE.md` renders correctly on GitHub
- [ ] Re-run `./setup-env.sh` and confirm the new section syncs into `~/.claude/CLAUDE.md`