### PR TITLE
Add team settings sync and deep-review context input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,15 @@ This is the **tzander-skills** Claude Code plugin marketplace (MIT License, Tim 
 
 The shared `~/.claude/CLAUDE.md` (team coding standards) is sourced from `standards/CLAUDE.md` in this repo. When asked to add or edit shared/team rules, modify `standards/CLAUDE.md` — not the developer's `~/.claude/CLAUDE.md` directly.
 
+The shared `~/.claude/settings.json` (team permission rules and settings) is sourced from `standards/settings.json`. The sync scripts deep-merge team settings into the user's existing settings (arrays are unioned, objects are merged, personal entries are preserved). When asked to add or edit shared settings, modify `standards/settings.json`.
+
 ## Environment Setup
 
 Run `./setup-env.sh` (bash) or `./setup-env.ps1` (PowerShell) to bootstrap the local environment:
 
 1. **Git hooks** — Installs global hooks from `hooks/` to `~/.git-hooks/` (controlled by `hooks/hooks.json`). Sets `core.hooksPath` globally.
 2. **Team standards** — Syncs `standards/CLAUDE.md` into `~/.claude/CLAUDE.md`.
+3. **Team settings** — Deep-merges `standards/settings.json` into `~/.claude/settings.json`.
 
 The script is idempotent — safe to re-run at any time. It replaces the old `sync-standards` scripts.
 

--- a/plugins/deep-review/README.md
+++ b/plugins/deep-review/README.md
@@ -13,7 +13,13 @@ Rigorous code review plugin that reviews all changes on the current branch compa
 
 ```
 /deep-review
+/deep-review focus on thread safety and error handling
+/deep-review https://github.com/org/repo/issues/42
+/deep-review https://dev.azure.com/org/project/_workitems/edit/1234
+/deep-review https://github.com/org/repo/pull/99 check auth edge cases
 ```
+
+Optional text after `/deep-review` provides additional context for the review. This can be a focus area, a GitHub issue/PR URL, an Azure DevOps work item URL, a plain URL, or any combination.
 
 ## What It Does
 

--- a/plugins/deep-review/commands/deep-review.md
+++ b/plugins/deep-review/commands/deep-review.md
@@ -2,7 +2,7 @@
 name: deep-review
 description: Perform a critical code review of all changes on the current branch compared to main
 disable-model-invocation: true
-allowed-tools: Bash, Read, Grep, Glob
+allowed-tools: Bash, Read, Grep, Glob, WebFetch
 model: opus
 ---
 
@@ -10,6 +10,22 @@ model: opus
 You are a ruthless code reviewer performing deep analysis of every change on the current branch compared to main. ultrathink
 
 **Your mandate:** Find every problem. Do not be agreeable. Do not give the benefit of the doubt. Do not hand-wave past code that "looks fine." If you cannot explain exactly why a line is correct, treat it as suspicious. If you find nothing, re-read the diff once more to be sure — but a genuinely clean change deserves a clean review.
+
+## Context Input
+
+The user may provide additional text after `/deep-review`. This text is: **$ARGUMENTS**
+
+If the text above is empty or blank, skip this section entirely and proceed with the standard review.
+
+Otherwise, use the text as **additional context** for your review. It may contain any of the following:
+
+- **A focus area** — free-form text describing what to pay special attention to (e.g., "focus on error handling" or "check thread safety"). Weight your review toward these concerns without ignoring other issues.
+- **A GitHub issue or PR URL** — use `gh issue view <number>` or `gh pr view <number>` (extract the number from the URL) to fetch the description and acceptance criteria. Use this to evaluate whether the implementation actually satisfies the requirements.
+- **An Azure DevOps work item URL** — use `az boards work-item show --id <id> --org <org-url> -o json` to fetch the work item details (extract the numeric ID from the URL). Use the acceptance criteria and description to evaluate whether the implementation satisfies the requirements.
+- **A plain URL** — fetch it with `WebFetch` and use the content as context for your review.
+- **A combination** — multiple inputs separated by spaces or newlines. Process all of them.
+
+When context is provided, add a **🎯 Context** line at the very top of your output (before ⚖️ Verdict) summarizing what additional context you used and how it informed your review. This is the ONLY additional section allowed — it goes above the five standard sections, not inside them. When evaluating Feature Fitness (Step 3), cross-reference the requirements from the context to verify the implementation addresses what was asked for — flag any gaps or scope drift.
 
 <!-- Keep in sync with standards/CLAUDE.md "Code Review Standards" -->
 **Non-negotiable principles:**

--- a/setup-env.ps1
+++ b/setup-env.ps1
@@ -167,4 +167,78 @@ $EndMarker
 }
 
 Write-Host ''
+
+###############################################################################
+# 3. Team settings sync
+###############################################################################
+
+Write-Host '=== Team Settings ==='
+
+$SettingsSource = Join-Path (Join-Path $RepoRoot 'standards') 'settings.json'
+$SettingsTarget = Join-Path $ClaudeDir 'settings.json'
+
+function Merge-JsonObjects {
+    param(
+        [Parameter(Mandatory)] $Base,
+        [Parameter(Mandatory)] $Override
+    )
+
+    if ($Base -is [System.Management.Automation.PSCustomObject] -and
+        $Override -is [System.Management.Automation.PSCustomObject]) {
+        $Result = [PSCustomObject]@{}
+        $AllKeys = @(($Base.PSObject.Properties.Name + $Override.PSObject.Properties.Name) | Sort-Object -Unique)
+        foreach ($Key in $AllKeys) {
+            $HasBase = $null -ne ($Base.PSObject.Properties | Where-Object { $_.Name -eq $Key })
+            $HasOverride = $null -ne ($Override.PSObject.Properties | Where-Object { $_.Name -eq $Key })
+            if ($HasBase -and $HasOverride) {
+                $Result | Add-Member -NotePropertyName $Key -NotePropertyValue (
+                    Merge-JsonObjects -Base $Base.$Key -Override $Override.$Key
+                )
+            }
+            elseif ($HasOverride) {
+                $Result | Add-Member -NotePropertyName $Key -NotePropertyValue $Override.$Key
+            }
+            else {
+                $Result | Add-Member -NotePropertyName $Key -NotePropertyValue $Base.$Key
+            }
+        }
+        return $Result
+    }
+    elseif ($Base -is [System.Collections.IEnumerable] -and $Base -isnot [string] -and
+            $Override -is [System.Collections.IEnumerable] -and $Override -isnot [string]) {
+        $Combined = @($Base) + @($Override) | Sort-Object -Unique
+        return @($Combined)
+    }
+    else {
+        return $Override
+    }
+}
+
+if (-not (Test-Path $SettingsSource)) {
+    Write-Host "No standards/settings.json found — skipping settings sync."
+}
+else {
+    $TeamSettings = Get-Content -Path $SettingsSource -Raw | ConvertFrom-Json
+
+    if (-not (Test-Path $SettingsTarget)) {
+        Copy-Item -Path $SettingsSource -Destination $SettingsTarget
+        Write-Host "Created $SettingsTarget with team settings."
+    }
+    else {
+        $ExistingSettings = Get-Content -Path $SettingsTarget -Raw | ConvertFrom-Json
+        $Merged = Merge-JsonObjects -Base $TeamSettings -Override $ExistingSettings
+        $MergedJson = $Merged | ConvertTo-Json -Depth 10
+
+        $ExistingJson = Get-Content -Path $SettingsTarget -Raw
+        if ($MergedJson.Trim() -eq $ExistingJson.Trim()) {
+            Write-Host "Settings in $SettingsTarget are already up to date."
+        }
+        else {
+            Set-Content -Path $SettingsTarget -Value $MergedJson -NoNewline
+            Write-Host "Merged team settings into $SettingsTarget."
+        }
+    }
+}
+
+Write-Host ''
 Write-Host '=== Setup complete ==='

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -163,4 +163,56 @@ ${END_MARKER}"
 fi
 
 echo ""
+
+###############################################################################
+# 3. Team settings sync
+###############################################################################
+
+echo "=== Team Settings ==="
+
+SETTINGS_SOURCE="$REPO_ROOT/standards/settings.json"
+SETTINGS_TARGET="$CLAUDE_DIR/settings.json"
+
+if [ ! -f "$SETTINGS_SOURCE" ]; then
+    echo "No standards/settings.json found — skipping settings sync."
+else
+    if ! command -v jq &>/dev/null; then
+        echo "Warning: jq is not installed — skipping settings.json sync." >&2
+    else
+        if [ ! -f "$SETTINGS_TARGET" ]; then
+            cp "$SETTINGS_SOURCE" "$SETTINGS_TARGET"
+            echo "Created $SETTINGS_TARGET with team settings."
+        else
+            # Deep-merge: team settings are the base, user settings win on
+            # scalar conflicts, arrays are unioned (deduplicated).
+            MERGED="$(jq -s '
+                def deep_merge:
+                    .[0] as $a | .[1] as $b |
+                    if ($a | type) == "object" and ($b | type) == "object" then
+                        ([($a | keys[]), ($b | keys[])] | unique) as $keys |
+                        reduce ($keys | .[]) as $k ({};
+                            if ($a | has($k)) and ($b | has($k))
+                            then . + { ($k): ([$a[$k], $b[$k]] | deep_merge) }
+                            elif ($b | has($k)) then . + { ($k): $b[$k] }
+                            else . + { ($k): $a[$k] }
+                            end)
+                    elif ($a | type) == "array" and ($b | type) == "array" then
+                        ($a + $b) | unique
+                    else $b
+                    end;
+                deep_merge
+            ' "$SETTINGS_SOURCE" "$SETTINGS_TARGET")"
+
+            EXISTING_SETTINGS="$(cat "$SETTINGS_TARGET")"
+            if [ "$MERGED" = "$EXISTING_SETTINGS" ]; then
+                echo "Settings in $SETTINGS_TARGET are already up to date."
+            else
+                printf '%s\n' "$MERGED" > "$SETTINGS_TARGET"
+                echo "Merged team settings into $SETTINGS_TARGET."
+            fi
+        fi
+    fi
+fi
+
+echo ""
 echo "=== Setup complete ==="

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -1,8 +1,9 @@
 # Team Coding Standards
 
 These standards are automatically synced into each developer's `~/.claude/CLAUDE.md`
-via the sync scripts at the repository root. Edit this file to update the team's standards,
-then have each developer re-run the sync script.
+via the sync scripts at the repository root. Team settings (`standards/settings.json`)
+are also synced into `~/.claude/settings.json`. Edit these files to update the team's
+standards, then have each developer re-run the sync script.
 
 ## Naming Conventions
 

--- a/standards/settings.json
+++ b/standards/settings.json
@@ -1,0 +1,6 @@
+{
+  "permissions": {
+    "allow": [],
+    "deny": []
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `standards/settings.json` and deep-merge logic to `setup-env.sh` / `setup-env.ps1` so team permission rules sync into each developer's `~/.claude/settings.json` (arrays unioned, objects merged, personal entries preserved)
- Extends `/deep-review` to accept optional context arguments (focus areas, GitHub issue/PR URLs, Azure DevOps work item URLs, plain URLs) for requirement-aware code review
- Updates `CLAUDE.md` and `standards/CLAUDE.md` to document the new settings sync

## Test plan
- [ ] Run `./setup-env.sh` — verify it creates/merges `~/.claude/settings.json`
- [ ] Run `./setup-env.ps1` — verify same behavior on PowerShell
- [ ] Run `/deep-review` with no arguments — confirm standard review works unchanged
- [ ] Run `/deep-review focus on error handling` — confirm context section appears in output
- [ ] Run `/deep-review <github-issue-url>` — confirm issue is fetched and used in review