### PR TITLE
Add standard: prefer new commits over amending

### DIFF
--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -160,6 +160,7 @@ query {
 
 - **Never push to `main` or `master`** — all changes must go through pull requests
 - **Never force push** (`--force`, `-f`, `--force-with-lease`) to any branch
+- **Always create new commits instead of amending** — amending requires force pushing to sync with the remote. When a pre-commit hook fails, fix the issue and create a new commit; do not `--amend` the previous one. Only amend if the user explicitly requests it and acknowledges the force push consequence.
 
 ## Git Hygiene Before New Work
 


### PR DESCRIPTION
## Summary
- Adds a rule to the "Git Push Safety" section in `standards/CLAUDE.md` requiring new commits instead of amending
- Explicitly covers the pre-commit hook failure scenario where amending is most tempting
- Aligns with the existing "never force push" guardrail — no amend means no force push needed

Closes #34

## Test plan
- [ ] Verify the rule appears in `standards/CLAUDE.md` under "Git Push Safety"
- [ ] Run sync script and confirm it propagates to `~/.claude/CLAUDE.md`