### PR TITLE
Add C# private field naming convention

### DIFF
--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -30,6 +30,7 @@ standards, then have each developer re-run the sync script.
 
 - Always use explicit types instead of `var` unless the type is immediately obvious from the right side of the assignment
 - Use `string.Empty` instead of `""`
+- Prefix private fields with `_` and use camelCase (e.g., `_connectionString`, `_logger`)
 
 ## Test Standards
 


### PR DESCRIPTION
## Summary
- Adds `_camelCase` naming rule for C# private fields to the shared team standards
- Placed in the existing C# section of `standards/CLAUDE.md` alongside `var` and `string.Empty` rules

Closes #45

## Test plan
- [ ] Verify the rule appears in `standards/CLAUDE.md` under the C# section
- [ ] Run sync script and confirm it propagates to `~/.claude/CLAUDE.md`