### PR TITLE
Fix PowerShell parse error in setup-env.ps1

### DIFF
--- a/setup-env.ps1
+++ b/setup-env.ps1
@@ -215,7 +215,7 @@ function Merge-JsonObjects {
 }
 
 if (-not (Test-Path $SettingsSource)) {
-    Write-Host "No standards/settings.json found — skipping settings sync."
+    Write-Host "No standards/settings.json found - skipping settings sync."
 }
 else {
     $TeamSettings = Get-Content -Path $SettingsSource -Raw | ConvertFrom-Json


### PR DESCRIPTION
## Summary
- Replaces UTF-8 em dash with ASCII dash on line 218 of `setup-env.ps1`
- PowerShell without a UTF-8 BOM uses the system ANSI codepage, which can't parse multi-byte UTF-8 characters, causing a string terminator error that prevents the script from running

## Test plan
- [ ] Run `.\setup-env.ps1` in PowerShell — verify it completes without parse errors