### PR TITLE
Fix pre-commit hook to check GIT_AUTHOR_EMAIL for GUI client compatibility

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -13,7 +13,9 @@
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"
 
 if [ -n "$repo_root" ] && [ -f "$repo_root/.commit-email-rules" ]; then
-    email="$(git config user.email 2>/dev/null)"
+    # Prefer GIT_AUTHOR_EMAIL (set by GUI clients like GitKraken)
+    # over git config, since the author email is what ends up on the commit.
+    email="${GIT_AUTHOR_EMAIL:-$(git config user.email 2>/dev/null)}"
 
     # Read allowed domain from rules file
     allowed_domain=""


### PR DESCRIPTION
## Summary

- GUI clients like GitKraken set `GIT_AUTHOR_EMAIL` from their own profile settings rather than reading `git config user.email`. The pre-commit hook was only checking `git config user.email`, so when a user's GitKraken profile had a different email than their git config, commits with the wrong email passed validation silently.
- The fix uses `${GIT_AUTHOR_EMAIL:-$(git config user.email)}` so the hook checks the environment variable first (which reflects what will actually appear on the commit) and falls back to `git config` when the variable isn't set (i.e., commits from the CLI).

## Test plan

- [ ] Run a commit from the CLI without `GIT_AUTHOR_EMAIL` set — hook should fall back to `git config user.email` and validate as before
- [ ] Run a commit with `GIT_AUTHOR_EMAIL` set to a valid domain email — hook should pass
- [ ] Run a commit with `GIT_AUTHOR_EMAIL` set to an invalid domain email — hook should reject the commit
- [ ] Run a commit in GitKraken with a mismatched profile email — hook should now catch the mismatch