### PR TITLE
Add test coverage requirements to shared standards

### DIFF
--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -32,9 +32,11 @@ standards, then have each developer re-run the sync script.
 - Use `string.Empty` instead of `""`
 - Prefix private fields with `_` and use camelCase (e.g., `_connectionString`, `_logger`)
 
-## Test Standards
+## Unit Test Standards
 
-### When to write tests
+These standards cover unit tests only. Integration and smoke test standards will be defined separately.
+
+### When to write unit tests
 
 - **New functionality:** All new code that contains logic (conditionals, calculations, transformations) must have accompanying tests
 - **Bug fixes:** Every bug fix must include a test that reproduces the bug and verifies the fix — this prevents recurrence
@@ -45,7 +47,7 @@ standards, then have each developer re-run the sync script.
   - UI-specific code that cannot be unit tested (e.g., view layouts, animations, platform-specific rendering)
   - Code where creating a test fixture would require disproportionate effort relative to the risk — use judgment, but document why tests were skipped in the PR description
 
-### How to write tests
+### How to write unit tests
 
 - Use the Arrange/Act/Assert pattern with comment separators
 - Name tests as `MethodName_Scenario_ExpectedBehavior`


### PR DESCRIPTION
## Summary
- Adds "When to write tests" section before existing style rules in `standards/CLAUDE.md`
- Requires tests for new functionality with logic, regression tests for bug fixes, and coverage before refactoring
- Lists exceptions: config, docs, prompt templates, pass-through wiring
- Existing style rules reorganized under "How to write tests" sub-heading

Closes #49

## Test plan
- [ ] Verify "When to write tests" appears before "How to write tests" in `standards/CLAUDE.md`
- [ ] Run sync script and confirm it propagates to `~/.claude/CLAUDE.md`