### PR TITLE
Allow agents to invoke deep-review via the Skill tool

### DIFF
--- a/plugins/deep-review/README.md
+++ b/plugins/deep-review/README.md
@@ -87,19 +87,6 @@ Agent({
 
 Each agent checks out its target branch, diffs against the specified base, runs the full review (including its own parallel subagents for correctness, testing, design, and assumptions analysis), and returns a structured verdict.
 
-## Agent Invocation
-
-Agents can invoke `/deep-review` via the Skill tool:
-
-```
-Agent({
-  description: "Deep review of current branch",
-  model: "opus",
-  prompt: "Use the Skill tool to invoke deep-review
-           with args: focus on error handling"
-})
-```
-
 ## What It Does
 
 Runs a structured, skeptical code review covering:
@@ -113,3 +100,21 @@ Runs a structured, skeptical code review covering:
 Uses parallel subagents to deeply analyze correctness/security, test coverage, design quality, and assumptions simultaneously — then merges and verifies findings into a single comprehensive output.
 
 Outputs a structured verdict with critical issues, simplification opportunities, and actionable feedback.
+
+## Agent Invocation
+
+Agents can invoke `/deep-review` via the Skill tool:
+
+```
+Skill({ skill: "deep-review", args: "focus on error handling" })
+```
+
+To run a review in the background while continuing other work:
+
+```
+Agent({
+  description: "Deep review of current branch",
+  model: "opus",
+  prompt: "Use the Skill tool to invoke deep-review. Your arguments are: focus on error handling"
+})
+```

--- a/plugins/deep-review/commands/deep-review.md
+++ b/plugins/deep-review/commands/deep-review.md
@@ -1,7 +1,7 @@
 ---
 name: deep-review
 description: Perform a critical code review of all changes on the current branch compared to a base branch (default main)
-disable-model-invocation: false
+disable-model-invocation: false # allows agents to invoke via Skill tool; all other plugins use true
 allowed-tools: Bash, Read, Grep, Glob, WebFetch, Agent
 model: opus
 ---
@@ -29,7 +29,7 @@ The user may provide additional text after `/deep-review`. This text is: **$ARGU
 
 If the text above literally reads `$ARGUMENTS` (not substituted), you are being invoked directly by an Agent rather than through the `/deep-review` slash command. In that case, look for arguments in your initial prompt (e.g., "Your arguments are: ...") and use those instead.
 
-If the resolved arguments are empty or blank, skip this section entirely and proceed with the standard review.
+If the arguments are empty or blank, skip this section entirely and proceed with the standard review.
 
 Otherwise, use the text as **additional context** for your review. It may contain any of the following:
 

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -250,7 +250,7 @@ After creating the feature branch but before any code research or changes, updat
 
 ## Pre-PR Checklist
 
-When asked to push a branch or create a pull request, remind the user to run `/deep-review` on the current branch if they haven't already done so during this session. Keep the reminder to a single sentence — do not block the push or PR.
+When asked to push a branch or create a pull request, remind the user to run `/deep-review` on the current branch if they haven't already done so during this session. Keep the reminder to a single sentence — do not block the push or PR. Do not auto-invoke `/deep-review`; always let the user decide.
 
 ## Phased Work
 


### PR DESCRIPTION
## Summary

- Sets `disable-model-invocation` to `false` so agents (and Claude) can invoke `/deep-review` programmatically via the Skill tool
- Adds `$ARGUMENTS` fallback detection in the command template for cases where an agent reads the file directly without plugin system substitution
- Documents the agent invocation pattern in the README

## Test plan

- [ ] Run `/deep-review` manually — verify it still works as before
- [ ] Spawn an Agent and have it invoke deep-review via the Skill tool — verify it works
- [ ] Verify Claude does not auto-trigger deep-review during unrelated conversations