### PR TITLE
docs: add token efficiency guidelines and configure craft plugins

### DIFF
--- a/plugins/craft-commit-push/commands/craft-commit-push.md
+++ b/plugins/craft-commit-push/commands/craft-commit-push.md
@@ -1,5 +1,6 @@
 ---
 name: craft-commit-push
+model: haiku
 description: Craft a commit message for staged changes and output a combined commit-and-push command
 disable-model-invocation: true
 allowed-tools: Bash, Read, Grep, Glob

--- a/plugins/craft-commit/commands/craft-commit.md
+++ b/plugins/craft-commit/commands/craft-commit.md
@@ -1,5 +1,6 @@
 ---
 name: craft-commit
+model: haiku
 description: Craft a commit message for all currently staged changes and output it as text and a ready-to-run command
 disable-model-invocation: true
 allowed-tools: Bash, Read, Grep, Glob

--- a/plugins/craft-pr/commands/craft-pr.md
+++ b/plugins/craft-pr/commands/craft-pr.md
@@ -1,5 +1,6 @@
 ---
 name: craft-pr
+model: haiku
 description: Generate a PR title and description, optionally creating the PR on GitHub or Azure DevOps
 disable-model-invocation: true
 allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion, WebFetch

--- a/plugins/craft-stage-commit-push/commands/craft-stage-commit-push.md
+++ b/plugins/craft-stage-commit-push/commands/craft-stage-commit-push.md
@@ -1,5 +1,6 @@
 ---
 name: craft-stage-commit-push
+model: haiku
 description: Filter junk files, stage meaningful changes, craft a commit message, and output a combined stage-commit-push command
 disable-model-invocation: true
 allowed-tools: Bash, Read, Grep, Glob

--- a/plugins/craft-stage/commands/craft-stage.md
+++ b/plugins/craft-stage/commands/craft-stage.md
@@ -1,5 +1,6 @@
 ---
 name: craft-stage
+model: haiku
 description: Analyze working directory changes, filter junk files, and output a ready-to-run git add command
 disable-model-invocation: true
 allowed-tools: Bash, Read, Grep, Glob

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -57,6 +57,36 @@ These standards cover unit tests only. Integration and smoke test standards will
 - Include at least one negative test (invalid input, failure scenario) per method under test
 - Tests should verify observable behavior, not implementation details
 
+## Model Selection and Token Efficiency
+
+### Task-to-model mapping
+
+**Opus — deep reasoning required:**
+- Code reviews (`/deep-review`) — multi-file analysis, security auditing, architectural assessment
+- Large refactors spanning multiple files or changing public APIs
+- Story improvement (`/improve-stories`) — codebase research + structured writing
+- Complex debugging requiring cross-module reasoning
+
+**Sonnet — standard development work:**
+- Feature implementation with clear requirements
+- Bug fixes with a known root cause or small scope
+- Writing tests for existing code
+- Documentation changes with codebase research
+
+**Haiku — mechanical or formulaic tasks:**
+- Generating commit messages, PR descriptions (`/craft-pr`, `/craft-commit`)
+- Simple file lookups, formatting, renaming
+- Staging commands (`/craft-stage`)
+- Subagent work with narrow, well-defined prompts (e.g., "fetch this issue and return the body")
+
+*Note: Model selection is a guideline, not a hard rule. Complex edge cases may need escalation to a more capable model.*
+
+### Context vs. Token Savings
+
+- Never sacrifice code context for token savings during a deep review. Quality and architectural verification require full file context.
+- Reserve token-aggressive strategies (like diff-only analysis) for mechanical summarization tasks (e.g., commit messages, PR descriptions).
+- Constrain subagent outputs: When writing prompts for intermediate subagents or plugins, ask the LLM to return succinct formats (like IDs, line numbers, or booleans) instead of conversational explanations to minimize expensive output tokens.
+
 ## Tool Usage
 
 - Prefer core tools (e.g., Read, Edit, Write, Grep, Glob, Agent, Bash) over MCP or other tools that require permission prompts — minimize interruptions to maximize velocity


### PR DESCRIPTION
Resolves #63.

## Summary
Adds documentation for model routing based on task scope and sets the default model to Haiku for mechanical plugins to save tokens.

## Changes
- Updated `standards/CLAUDE.md` to include a Model Selection and Token Efficiency section, establishing clear rules for Opus, Sonnet, and Haiku.
- Added explicit `model: haiku` frontmatter to `craft-pr`, `craft-commit`, `craft-stage`, `craft-commit-push`, and `craft-stage-commit-push` plugins.