### PR TITLE
feat: add self-review plugin skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -79,6 +79,14 @@
       "source": "./plugins/improve-stories",
       "category": "productivity",
       "strict": false
+    },
+    {
+      "name": "self-review",
+      "description": "Analyzes the current Claude Code session for meta-learnings and workflow improvements.",
+      "author": { "name": "Tim Zander" },
+      "source": "./plugins/self-review",
+      "category": "productivity",
+      "strict": false
     }
   ]
 }

--- a/plugins/self-review/.claude-plugin/plugin.json
+++ b/plugins/self-review/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
+  "name": "self-review",
+  "version": "0.1.0",
+  "description": "Analyzes the current Claude Code session for meta-learnings and workflow improvements.",
+  "commands": [
+    {
+      "name": "self-review",
+      "resolve": "../commands/self-review.md"
+    }
+  ]
+}

--- a/plugins/self-review/README.md
+++ b/plugins/self-review/README.md
@@ -1,0 +1,13 @@
+# Self-Review Plugin
+
+The `/self-review` skill initiates a reflection process where Claude evaluates its current session for missing documentation, team-wide workflow gaps, or potential new skills. 
+
+## Design
+Claude is notoriously forgetful from session to session. To bootstrap better tooling, we use `/self-review` when finishing an ad-hoc session to extract insights from the immediate context window. 
+
+This plugin prompts Claude to analyze the recent session and route the findings into actionable tasks:
+- **Repo-specific insights:** Written directly to the LOCAL repository's `CLAUDE.md`.
+- **Team-wide standards & Skill opportunities:** Created as GitHub issues explicitly tracked over on the `TimZander/claude` repository.
+
+## Usage
+`> /self-review [optional focus area]`

--- a/plugins/self-review/commands/self-review.md
+++ b/plugins/self-review/commands/self-review.md
@@ -1,0 +1,37 @@
+---
+name: self-review
+description: Synthesizes the current session into repo-specific learnings, team-wide improvements, and new skill opportunities.
+allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion
+user-input: optional
+argument-hint: "[focus-area]"
+model: opus
+---
+
+You are a meta-learning agent analyzing the current development session. Your task is to identify friction points, missing context, or repetitive workflows and recommend improvements.
+
+## Constraints
+- **Context limit:** You do not have a programmatic "session transcript API". You must rely entirely on your in-context memory of the conversation. If the session has been exceedingly long, acknowledge that earlier parts may have fallen out of context.
+- **Cross-Repo Operation:** This skill will almost universally be run in a different repository than the skills repository itself. 
+- **Read-only by default:** Never run write commands (`gh issue create` or file writes) without explicitly listing out the tasks and asking the user via the `AskUserQuestion` tool first. Do not make any changes in the background without explicit approval!
+
+## Output Format & Actions
+First, silently reflect on your immediate memory of the latest prompts, bugs, and workflows in the session. Present your findings grouped into these three categories. If a category yields no findings, state so.
+
+### 1. Repo-specific learning
+- **Trigger:** We lacked documentation or explicit instructions in the repository context to do the work seamlessly.
+- **Action:** Propose appending an exact text block or documentation rule to the **current repository's** `CLAUDE.md` file. Provide exactly what text you will insert.
+
+### 2. Team-wide improvement
+- **Trigger:** We hit CI flakiness, deployment issues, cross-project pain points, or general workflow friction.
+- **Action:** Propose creating a GitHub issue. This issue must be explicitly created on the `TimZander/claude` repository (`gh issue create --repo TimZander/claude`). Format the proposal mimicking the `/improve-stories` style (Markdown structure, clear goals, acceptance criteria).
+
+### 3. Skill opportunity
+- **Trigger:** We performed repetitive, multi-step tool interactions that could be bundled into a new reusable plugin or command.
+- **Action:** Propose creating a GitHub issue for a new skill. Just like the team-wide improvement, this must be created explicitly on the `TimZander/claude` repository (`gh issue create --repo TimZander/claude`). Explain why a new skill is warranted over standard static documentation.
+
+## Execution
+1. Output your categorized analysis cleanly to the console. 
+2. Show each proposed item alongside the explicit execution command (e.g. `I will run gh issue create --repo TimZander/claude...`) 
+3. Ask the user: "Would you like me to execute these actions? Provide a list of item numbers to approve, or say 'yes to all'."
+4. Use the `AskUserQuestion` tool to block and get explicit permission.
+5. Once approved, use `Bash` or your file-editing tools to apply the approved changes.


### PR DESCRIPTION
Resolves #62.

## Summary
Adds the new `/self-review` meta-plugin.

## Changes
- Creates `plugins/self-review/commands/self-review.md` routing context learnings explicitly to local paths or the centralized skills repository depending on finding topology.
- Introduces `AskUserQuestion` blocking on all write operations.
- Registers plugin in `marketplace.json`.