### PR TITLE
Fix: Avoid temp files for issue creation in skills

### DIFF
--- a/plugins/improve-stories/commands/improve-stories.md
+++ b/plugins/improve-stories/commands/improve-stories.md
@@ -291,7 +291,7 @@ Before updating each item, verify:
 - Do NOT begin implementation — the deliverable is the updated description.
 - If an update fails, report the error and continue with the remaining items.
 
-**GitHub:** Write the new body to a temp file, then use `gh issue edit <number> --body-file /tmp/issue-body.md` to update the issue. This avoids shell escaping issues with quotes, backticks, and `$` in markdown content. After each successful update, add an audit trail comment with `gh issue comment <number> --body "Description restructured — added [what was added] based on codebase research."`.
+**GitHub:** Use `gh issue edit <number> --body "..."` to update the issue. Take care to use appropriate shell quoting for the markdown body content rather than writing to a temporary file. After each successful update, add an audit trail comment with `gh issue comment <number> --body "Description restructured — added [what was added] based on codebase research."`.
 
 **ADO:** Write the updated description to each ADO work item using the update tool. After each successful update, add a brief work item comment noting what was changed (e.g., "Description restructured — added root cause analysis, acceptance criteria, and proposed fix based on codebase research."). This creates an audit trail so reviewers know the description was reworked.
 

--- a/plugins/self-review/commands/self-review.md
+++ b/plugins/self-review/commands/self-review.md
@@ -17,6 +17,8 @@ You are a meta-learning agent analyzing the current development session. Your ta
 ## Output Format & Actions
 First, silently reflect on your immediate memory of the latest prompts, bugs, and workflows in the session. Present your findings grouped into these three categories. If a category yields no findings, state so.
 
+**Constraint:** When proposing `gh issue create`, ALWAYS use the `--body` argument with appropriate shell quoting rather than asking to write a temporary file first. This minimizes the number of permission prompts.
+
 ### 1. Repo-specific learning
 - **Trigger:** We lacked documentation or explicit instructions in the repository context to do the work seamlessly.
 - **Action:** Propose appending an exact text block or documentation rule to the **current repository's** `CLAUDE.md` file. Provide exactly what text you will insert.

--- a/plugins/self-review/commands/self-review.md
+++ b/plugins/self-review/commands/self-review.md
@@ -13,11 +13,17 @@ You are a meta-learning agent analyzing the current development session. Your ta
 - **Context limit:** You do not have a programmatic "session transcript API". You must rely entirely on your in-context memory of the conversation. If the session has been exceedingly long, acknowledge that earlier parts may have fallen out of context.
 - **Cross-Repo Operation:** This skill will almost universally be run in a different repository than the skills repository itself. 
 - **Read-only by default:** Never run write commands (`gh issue create` or file writes) without explicitly listing out the tasks and asking the user via the `AskUserQuestion` tool first. Do not make any changes in the background without explicit approval!
+- **Inline heredoc for `gh issue` bodies:** When running `gh issue create`, `gh issue edit`, or `gh issue comment` — both in the command shown to the user for approval and when executing it afterward — pass the body inline via a heredoc rather than writing a temp file. Each file write triggers its own permission prompt, and shell-quoting long markdown bodies with backticks, `$`, or nested quotes is fragile. Use a single-quoted `ENDOFBODY` delimiter so special characters are preserved verbatim:
+  ```bash
+  gh issue create --repo TimZander/claude --title "<title>" --body "$(cat <<'ENDOFBODY'
+  <full markdown body — code fences, `backticks`, $vars, and "quotes" preserved>
+  ENDOFBODY
+  )"
+  ```
+  Use `ENDOFBODY` (not `EOF`) to avoid early termination when the body itself contains shell examples with `EOF`.
 
 ## Output Format & Actions
 First, silently reflect on your immediate memory of the latest prompts, bugs, and workflows in the session. Present your findings grouped into these three categories. If a category yields no findings, state so.
-
-**Constraint:** When proposing `gh issue create`, ALWAYS use the `--body` argument with appropriate shell quoting rather than asking to write a temporary file first. This minimizes the number of permission prompts.
 
 ### 1. Repo-specific learning
 - **Trigger:** We lacked documentation or explicit instructions in the repository context to do the work seamlessly.


### PR DESCRIPTION
Fixes #81.

## Context

Issue #81 was closed by commit 988107a ("replace temp file writes with heredoc patterns") which landed on main while this PR was open. That commit covered `improve-stories.md`, `craft-pr.md`, and `standards/CLAUDE.md` — but missed `self-review.md`. This PR completes the coverage for the self-review plugin using the same heredoc pattern.

## Change

Adds a constraint to `plugins/self-review/commands/self-review.md` that directs the skill to pass `gh issue create`/`edit`/`comment` bodies inline via a single-quoted `ENDOFBODY` heredoc, rather than writing to a temp file. Includes a worked example so the plugin is self-contained for consumers installing it via the marketplace.

## Why not `--body "..."` with shell quoting

The original version of this PR proposed `--body "..."` with "appropriate shell quoting". During the merge with main, that wording was superseded in `improve-stories.md` because long markdown bodies with backticks, `$`, or nested quotes break plain shell quoting — exactly the case called out in AC #4 of #81. The heredoc pattern sidesteps all of that.