### PR TITLE
Replace temp file writes with heredoc patterns in plugin workflows

### DIFF
--- a/plugins/craft-pr/commands/craft-pr.md
+++ b/plugins/craft-pr/commands/craft-pr.md
@@ -160,8 +160,19 @@ Output the full markdown description in a code block:
      <full PR description from Step 4 — nothing else>
      ENDOFBODY
      ```
-   - **`Linux`:** Same pattern but pipe to `xclip -selection clipboard` (falls back to `xsel --clipboard --input` if `xclip` is not installed)
-   - **`MINGW`/`MSYS`/`CYGWIN` (Windows):** Same pattern but pipe to `clip`
+   - **`Linux`:**
+     ```bash
+     cat << 'ENDOFBODY' | xclip -selection clipboard
+     <full PR description from Step 4 — nothing else>
+     ENDOFBODY
+     ```
+     Falls back to `xsel --clipboard --input` if `xclip` is not installed.
+   - **`MINGW`/`MSYS`/`CYGWIN` (Windows):**
+     ```bash
+     cat << 'ENDOFBODY' | clip
+     <full PR description from Step 4 — nothing else>
+     ENDOFBODY
+     ```
 3. Tell the user the PR description has been copied to their clipboard. Do not create the PR. Stop here.
 
 ## Step 7: Create PR (only when `--create` flag is provided)

--- a/plugins/craft-pr/commands/craft-pr.md
+++ b/plugins/craft-pr/commands/craft-pr.md
@@ -153,18 +153,16 @@ Output the full markdown description in a code block:
 
 **If the user did NOT pass `--create`**:
 1. Run `echo "OS=$(uname -s)"` to detect the user's operating system.
-2. Write the description to a temp file using a heredoc so special characters are preserved:
-   ```bash
-   BODY_FILE=$(mktemp)
-   cat > "$BODY_FILE" << 'ENDOFBODY'
-   <full PR description from Step 4 — nothing else>
-   ENDOFBODY
-   ```
-3. Use Bash to pipe the temp file to the clipboard based on the detected OS:
-   - **`Darwin` (macOS):** `cat "$BODY_FILE" | pbcopy`
-   - **`Linux`:** `cat "$BODY_FILE" | xclip -selection clipboard` (falls back to `xsel --clipboard --input` if `xclip` is not installed)
-   - **`MINGW`/`MSYS`/`CYGWIN` (Windows):** `cat "$BODY_FILE" | clip`
-4. Tell the user the PR description has been copied to their clipboard. Do not create the PR. Stop here.
+2. Pipe the description directly to the clipboard using a heredoc — no temp file needed:
+   - **`Darwin` (macOS):**
+     ```bash
+     cat << 'ENDOFBODY' | pbcopy
+     <full PR description from Step 4 — nothing else>
+     ENDOFBODY
+     ```
+   - **`Linux`:** Same pattern but pipe to `xclip -selection clipboard` (falls back to `xsel --clipboard --input` if `xclip` is not installed)
+   - **`MINGW`/`MSYS`/`CYGWIN` (Windows):** Same pattern but pipe to `clip`
+3. Tell the user the PR description has been copied to their clipboard. Do not create the PR. Stop here.
 
 ## Step 7: Create PR (only when `--create` flag is provided)
 
@@ -172,31 +170,26 @@ Output the full markdown description in a code block:
 
 The `create-pr.sh` script handles platform detection, pre-flight checks, pushing, and PR creation. You provide the title and description; the script does the rest.
 
-### 7a: Write description to a temp file
+### 7a: Write description and locate the script
 
-Shell escaping a multi-line markdown body is unreliable. Write the description to a temp file first:
+Combine the temp file write and script lookup in a single Bash call to avoid a separate permission prompt for the file write:
 
 ```bash
-BODY_FILE=$(mktemp)
-cat > "$BODY_FILE" << 'ENDOFBODY'
+BODY_FILE=$(mktemp) && cat > "$BODY_FILE" << 'ENDOFBODY'
 <full PR description from Step 4 — nothing else>
 ENDOFBODY
-echo "$BODY_FILE"
+SCRIPT=$(find ~/.claude -name create-pr.sh -path "*/craft-pr/*" -type f 2>/dev/null | head -1)
+echo "BODY_FILE=$BODY_FILE"
+echo "SCRIPT=$SCRIPT"
 ```
 
-Use a heredoc with **single-quoted delimiter** (`<< 'ENDOFBODY'`) so the shell does not interpret special characters. The `echo` prints the temp file path to stdout.
+Use a heredoc with **single-quoted delimiter** (`<< 'ENDOFBODY'`) so the shell does not interpret special characters. The script handles cleanup of the temp file on exit.
 
-### 7b: Locate the script
+### 7b: Run the script
 
-```bash
-find ~/.claude -name create-pr.sh -path "*/craft-pr/*" -type f 2>/dev/null | head -1
-```
+If the script was not found in 7a, stop and tell the user: "Could not locate `create-pr.sh`. Re-install the craft-pr plugin: `/plugin install craft-pr@tzander-skills`."
 
-If the script is not found, stop and tell the user: "Could not locate `create-pr.sh`. Re-install the craft-pr plugin: `/plugin install craft-pr@tzander-skills`."
-
-### 7c: Run the script
-
-**Important:** Shell state does not persist between Bash tool calls. Use the literal paths printed by the previous steps — do not rely on shell variables.
+**Important:** Shell state does not persist between Bash tool calls. Use the literal paths printed by Step 7a — do not rely on shell variables.
 
 ```bash
 bash "<script-path>" --title "<title>" --body-file "<body-file-path>" [--draft]
@@ -204,7 +197,7 @@ bash "<script-path>" --title "<title>" --body-file "<body-file-path>" [--draft]
 
 If the user passed `--draft`, include the `--draft` flag.
 
-### 7d: Handle the result
+### 7c: Handle the result
 
 - **Exit code 0** — PR created successfully. Report the URL from the script output.
 - **Exit code 2** — Uncommitted changes detected. The body file was preserved. Use AskUserQuestion to ask the user whether to proceed (the remote will not include uncommitted changes). If yes, re-run the script with `--skip-dirty-check` and the **same `--body-file` path**:

--- a/plugins/improve-stories/commands/improve-stories.md
+++ b/plugins/improve-stories/commands/improve-stories.md
@@ -293,12 +293,12 @@ Before updating each item, verify:
 
 **GitHub:** Use a heredoc to pass the body inline, avoiding temp file writes (which trigger extra permission prompts):
 ```bash
-gh issue edit <number> --body "$(cat <<'EOF'
+gh issue edit <number> --body "$(cat <<'ENDOFBODY'
 <full updated description>
-EOF
+ENDOFBODY
 )"
 ```
-The single-quoted `'EOF'` delimiter prevents shell expansion, so backticks, `$`, and quotes in the markdown are preserved. After each successful update, add an audit trail comment with `gh issue comment <number> --body "Description restructured — added [what was added] based on codebase research."`.
+The single-quoted `'ENDOFBODY'` delimiter prevents shell expansion, so backticks, `$`, and quotes in the markdown are preserved. Use `ENDOFBODY` (not `EOF`) to avoid early termination if the content contains shell examples. After each successful update, add an audit trail comment with `gh issue comment <number> --body "Description restructured — added [what was added] based on codebase research."`.
 
 **ADO:** Write the updated description to each ADO work item using the update tool. After each successful update, add a brief work item comment noting what was changed (e.g., "Description restructured — added root cause analysis, acceptance criteria, and proposed fix based on codebase research."). This creates an audit trail so reviewers know the description was reworked.
 

--- a/plugins/improve-stories/commands/improve-stories.md
+++ b/plugins/improve-stories/commands/improve-stories.md
@@ -291,7 +291,14 @@ Before updating each item, verify:
 - Do NOT begin implementation — the deliverable is the updated description.
 - If an update fails, report the error and continue with the remaining items.
 
-**GitHub:** Write the new body to a temp file, then use `gh issue edit <number> --body-file /tmp/issue-body.md` to update the issue. This avoids shell escaping issues with quotes, backticks, and `$` in markdown content. After each successful update, add an audit trail comment with `gh issue comment <number> --body "Description restructured — added [what was added] based on codebase research."`.
+**GitHub:** Use a heredoc to pass the body inline, avoiding temp file writes (which trigger extra permission prompts):
+```bash
+gh issue edit <number> --body "$(cat <<'EOF'
+<full updated description>
+EOF
+)"
+```
+The single-quoted `'EOF'` delimiter prevents shell expansion, so backticks, `$`, and quotes in the markdown are preserved. After each successful update, add an audit trail comment with `gh issue comment <number> --body "Description restructured — added [what was added] based on codebase research."`.
 
 **ADO:** Write the updated description to each ADO work item using the update tool. After each successful update, add a brief work item comment noting what was changed (e.g., "Description restructured — added root cause analysis, acceptance criteria, and proposed fix based on codebase research."). This creates an audit trail so reviewers know the description was reworked.
 

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -163,6 +163,14 @@ These standards and skills (`plugins/`) are configured for the Claude Code toolc
 
 - Prefer core tools (e.g., Read, Edit, Write, Grep, Glob, Agent, Bash) over MCP or other tools that require permission prompts — minimize interruptions to maximize velocity
 - When core tools are insufficient or significantly less efficient, external tools and custom scripts (Python, etc.) are acceptable
+- **Avoid writing temp files to pass text to CLI commands.** Each file write triggers its own permission prompt. Instead, use a heredoc to pass content inline:
+  ```bash
+  gh issue edit 42 --body "$(cat <<'EOF'
+  Markdown body with `backticks`, $variables, and "quotes" preserved.
+  EOF
+  )"
+  ```
+  The single-quoted `'EOF'` delimiter prevents shell expansion. When a tool genuinely requires a file path (e.g., `--body-file`, `@file`), combine the file write and the consuming command in a single Bash call to avoid a separate permission prompt for the write.
 - If a particular external tool or workflow pattern is used repeatedly across multiple sessions, suggest creating a skill to wrap the common usage
 - **ADO MCP: always resolve repository GUIDs before creating PRs.** `repo_create_pull_request` requires a repository GUID for `repositoryId` — passing a name or `Project/Name` produces misleading errors. Call `repo_get_repo_by_name_or_id` first to resolve the name to a GUID.
 

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -165,12 +165,12 @@ These standards and skills (`plugins/`) are configured for the Claude Code toolc
 - When core tools are insufficient or significantly less efficient, external tools and custom scripts (Python, etc.) are acceptable
 - **Avoid writing temp files to pass text to CLI commands.** Each file write triggers its own permission prompt. Instead, use a heredoc to pass content inline:
   ```bash
-  gh issue edit 42 --body "$(cat <<'EOF'
+  gh issue edit 42 --body "$(cat <<'ENDOFBODY'
   Markdown body with `backticks`, $variables, and "quotes" preserved.
-  EOF
+  ENDOFBODY
   )"
   ```
-  The single-quoted `'EOF'` delimiter prevents shell expansion. When a tool genuinely requires a file path (e.g., `--body-file`, `@file`), combine the file write and the consuming command in a single Bash call to avoid a separate permission prompt for the write.
+  The single-quoted `'ENDOFBODY'` delimiter prevents shell expansion. Use a unique delimiter (`ENDOFBODY`, not `EOF`) to avoid early termination if the content itself contains shell examples with `EOF`. When a tool genuinely requires a file path (e.g., `--body-file`, `@file`), combine the file write and the consuming command in a single Bash call to avoid a separate permission prompt for the write.
 - If a particular external tool or workflow pattern is used repeatedly across multiple sessions, suggest creating a skill to wrap the common usage
 - **ADO MCP: always resolve repository GUIDs before creating PRs.** `repo_create_pull_request` requires a repository GUID for `repositoryId` — passing a name or `Project/Name` produces misleading errors. Call `repo_get_repo_by_name_or_id` first to resolve the name to a GUID.
 


### PR DESCRIPTION
## Summary

- Adds a general "avoid temp files" guideline to `standards/CLAUDE.md` under Tool Usage, with the heredoc pattern and rationale
- Updates `improve-stories` to use inline `--body "$(cat <<'EOF' ... EOF)"` instead of writing to `/tmp/issue-body.md`
- Updates `craft-pr` Step 6 (clipboard copy) to pipe heredoc directly to clipboard instead of writing a temp file first
- Updates `craft-pr` Step 7a to combine temp file write + script lookup into a single Bash call, reducing from 2 permission prompts to 1. The script's `--body-file` interface is preserved since `create-pr.sh` handles cleanup and ADO requires file paths.

Closes #81

## Test plan

- [ ] Run `/improve-stories` on an issue — verify `gh issue edit` uses inline heredoc, no `/tmp` file written
- [ ] Run `/craft-pr` (without `--create`) — verify description is piped directly to clipboard without a temp file
- [ ] Run `/craft-pr --create` — verify the temp file write and script lookup happen in a single Bash call
- [ ] Verify markdown with backticks, `$`, and quotes is preserved correctly in all three workflows