### PR TITLE
Compile Antigravity skills to global user directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 __pycache__/
 *.pyc
 .claude/settings.local.json
-.agent/

--- a/plugins/craft-stage-commit-push/.claude-plugin/plugin.json
+++ b/plugins/craft-stage-commit-push/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "craft-stage-commit-push",
+  "description": "Filter junk files, stage meaningful changes, craft a commit message, and output a combined stage-commit-push command",
+  "author": {
+    "name": "Tim Zander"
+  }
+}

--- a/scripts/antigravity-sync.py
+++ b/scripts/antigravity-sync.py
@@ -21,7 +21,9 @@ def _yaml_quote(value: str) -> str:
 def sync_plugins_to_antigravity():
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     plugins_dir = os.path.join(repo_root, "plugins")
-    agents_skills_dir = os.path.join(repo_root, ".agent", "skills")
+    agents_skills_dir = os.path.join(
+        os.path.expanduser("~"), ".gemini", "antigravity", "skills"
+    )
 
     # Wipe stale output so renamed/deleted plugins don't linger
     if os.path.isdir(agents_skills_dir):
@@ -43,7 +45,7 @@ def sync_plugins_to_antigravity():
         found_plugin_dirs.add(os.path.basename(plugin_root_dir))
 
         try:
-            with open(plugin_file, "r") as f:
+            with open(plugin_file, "r", encoding="utf-8") as f:
                 data = json.load(f)
 
             name = data.get("name")
@@ -68,7 +70,7 @@ def sync_plugins_to_antigravity():
                 print(f"Warning: Prompt markdown not found for {name}")
                 continue
 
-            with open(md_path, "r") as f:
+            with open(md_path, "r", encoding="utf-8") as f:
                 md_content = f.read()
 
             skill_dir = os.path.join(agents_skills_dir, name)
@@ -84,7 +86,7 @@ def sync_plugins_to_antigravity():
                     content_body = parts[2].strip()
 
             # Use _yaml_quote for safe YAML serialization (handles quotes, colons, etc.)
-            with open(skill_file_path, "w") as f:
+            with open(skill_file_path, "w", encoding="utf-8") as f:
                 f.write("---\n")
                 f.write(f"name: {_yaml_quote(name)}\n")
                 f.write(f"description: {_yaml_quote(description)}\n")

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -126,8 +126,8 @@ fi
 These standards and skills (`plugins/`) are configured for the Claude Code toolchain (`.claude-plugin/marketplace.json`) but can be compiled into Google **Antigravity** skill format using a translation script.
 
 - **To compile Claude plugins into Antigravity `SKILL.md` structures**, run `python scripts/antigravity-sync.py`.
-- This compiles and symlinks plugin sources to `.agent/skills/<name>`.
-- **DO NOT** manually edit files in `.agent/skills/`. They are overwritten on compilation. Edit the primary sources in `plugins/`!
+- This compiles plugin sources to `~/.gemini/antigravity/skills/<name>` (user-global, available in every workspace).
+- **DO NOT** manually edit files in `~/.gemini/antigravity/skills/`. They are overwritten on compilation. Edit the primary sources in `plugins/`!
 
 ## Model Selection and Token Efficiency
 


### PR DESCRIPTION
## Problem

The ntigravity-sync.py script compiled skills to .agent/skills/ inside the repo, making them only available when Antigravity's workspace was this specific repo. Additionally, craft-stage-commit-push was silently skipped due to a missing plugin.json, and deep-review failed to compile on Windows due to encoding errors.

## Changes

- **Global output path** — Changed ntigravity-sync.py to write compiled skills to ~/.gemini/antigravity/skills/ instead of the repo-local .agent/skills/. Skills are now available in every workspace.
- **Missing plugin metadata** — Added .claude-plugin/plugin.json for craft-stage-commit-push so it's no longer skipped by the sync script.
- **UTF-8 encoding** — Added explicit encoding='utf-8' to all open() calls, fixing charmap codec errors on Windows (e.g. deep-review.md contains non-ASCII characters).
- **Documentation** — Updated standards/CLAUDE.md to reflect the new global path.
- **Gitignore cleanup** — Removed the stale .agent/ entry (no longer needed since output goes to user home).

## Verification

Ran python scripts/antigravity-sync.py — all 11 plugins compiled successfully to ~/.gemini/antigravity/skills/.