### PR TITLE
Add Pasted Log Handling section to team standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 .claude/settings.local.json
+.claude-scratch/

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -174,6 +174,16 @@ These standards and skills (`plugins/`) are configured for the Claude Code toolc
 - If a particular external tool or workflow pattern is used repeatedly across multiple sessions, suggest creating a skill to wrap the common usage
 - **ADO MCP: always resolve repository GUIDs before creating PRs.** `repo_create_pull_request` requires a repository GUID for `repositoryId` — passing a name or `Project/Name` produces misleading errors. Call `repo_get_repo_by_name_or_id` first to resolve the name to a GUID.
 
+## Pasted Log Handling
+
+When the user pastes a log longer than ~100 lines (device log, server log, CI log, stack trace, config dump, etc.), the **first action** should be to `Write` the content to a scratch file under `/tmp/` (e.g. `/tmp/pastedlog-<epoch>.txt`). All subsequent analysis uses `Grep` / `Read` on that file rather than re-scanning the paste in context.
+
+For broad correlation tasks spanning many events, delegate to an `Agent({subagent_type: "Explore"})` with just the file path. This keeps the full log out of the main conversation's context window — the sub-agent burns its own context on the read-and-summarize work and returns only a compact structured result.
+
+This pattern preserves the user's paste-based workflow (no behavior change on the user's side) while avoiding repeated context costs from re-scanning the same log for different questions. The first-paste cost is unavoidable, but every subsequent query becomes near-free.
+
+**When to use repo-relative scratch instead of `/tmp/`:** if the user indicates they want cross-session persistence ("come back to this log tomorrow"), write to `.claude-scratch/` in the repo root and ensure it is in `.gitignore`. Default to `/tmp/` otherwise.
+
 ## Troubleshooting Failures
 
 When a deployment, infrastructure operation, or third-party integration fails with an unexpected error:

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -176,13 +176,17 @@ These standards and skills (`plugins/`) are configured for the Claude Code toolc
 
 ## Pasted Log Handling
 
-When the user pastes a log longer than ~100 lines (device log, server log, CI log, stack trace, config dump, etc.), the **first action** should be to `Write` the content to a scratch file under `/tmp/` (e.g. `/tmp/pastedlog-<epoch>.txt`). All subsequent analysis uses `Grep` / `Read` on that file rather than re-scanning the paste in context.
+When the user pastes a log longer than ~100 lines (device log, server log, CI log, stack trace, config dump, test output, etc.), the **first action** should be to `Write` the content to a scratch file so later turns can `Grep` / `Read` against it rather than re-tokenizing the full paste. The ~100 line threshold is approximate — below that size the write + grep overhead exceeds the benefit. (This is distinct from the "avoid temp files" rule in Tool Usage above, which governs passing text to CLI commands; here the file is for Claude's own later analysis.)
 
-For broad correlation tasks spanning many events, delegate to an `Agent({subagent_type: "Explore"})` with just the file path. This keeps the full log out of the main conversation's context window — the sub-agent burns its own context on the read-and-summarize work and returns only a compact structured result.
+**Where to write:** default to the system temp directory — `/tmp/pastedlog-<unix-epoch-seconds>.txt` on Unix/macOS (e.g. `/tmp/pastedlog-1714567890.txt`), or `$env:TEMP\pastedlog-<unix-epoch-seconds>.txt` on Windows. When the user wants cross-session persistence ("come back to this log tomorrow"), write to `.claude-scratch/` in the repo root instead — and before the first write, verify `.claude-scratch/` is listed in the repo's `.gitignore` and append it if not. Pasted logs frequently contain tokens, connection strings, and PII; `/tmp/` is world-readable on multi-user hosts, so when the paste is likely to contain secrets prefer `.claude-scratch/`.
 
-This pattern preserves the user's paste-based workflow (no behavior change on the user's side) while avoiding repeated context costs from re-scanning the same log for different questions. The first-paste cost is unavoidable, but every subsequent query becomes near-free.
+**Correlation tasks:** for work spanning many events, delegate to an `Agent({subagent_type: "general-purpose"})` with just the file path. The sub-agent reads and summarizes inside its own context window; only the compact result comes back to the main thread.
 
-**When to use repo-relative scratch instead of `/tmp/`:** if the user indicates they want cross-session persistence ("come back to this log tomorrow"), write to `.claude-scratch/` in the repo root and ensure it is in `.gitignore`. Default to `/tmp/` otherwise.
+**Multi-turn pastes:** when the user pastes additional chunks of the same log across multiple turns, append to the existing scratch file with a short `--- chunk N ---` separator rather than creating new files.
+
+**Cleanup:** delete the scratch file when the investigation wraps. `/tmp/` typically self-cleans on reboot; `.claude-scratch/` does not.
+
+The first-paste token cost is unavoidable, but every follow-up query avoids re-tokenizing the full paste.
 
 ## Troubleshooting Failures
 

--- a/standards/settings.json
+++ b/standards/settings.json
@@ -1,6 +1,9 @@
 {
   "permissions": {
-    "allow": [],
+    "allow": [
+      "Write(/tmp/pastedlog-*)",
+      "Write(.claude-scratch/**)"
+    ],
     "deny": []
   }
 }


### PR DESCRIPTION
## Summary

- Add a **Pasted Log Handling** section to `standards/CLAUDE.md`, positioned between **Tool Usage** and **Troubleshooting Failures**.
- Directs Claude to write logs longer than ~100 lines to a scratch file on arrival, then use `Grep` / `Read` / `Agent(Explore)` against that file instead of re-scanning the paste for each follow-up question.
- Preserves the user's paste-based workflow; the change is entirely in Claude's downstream handling.

Closes #94

## Test plan

- [ ] Confirm the new section renders correctly in GitHub's markdown preview.
- [ ] Re-run `./setup-env.sh` (or `.ps1`) locally and verify the section appears in `~/.claude/CLAUDE.md`.
- [ ] Paste a >100-line log into a future Claude Code session and confirm it gets written to `/tmp/` as the first action.