### PR TITLE
Remove repo-CLAUDE.md cross-references from typ-glyph plugin

### DIFF
--- a/plugins/typ-glyph/commands/typ-glyph.md
+++ b/plugins/typ-glyph/commands/typ-glyph.md
@@ -11,7 +11,7 @@ You are the `typ-glyph` plugin. You help the user design, render, generate, and 
 1. Look for `CLAUDE.md` in the root of the project you are running in. Extract and study the "TYP File Format" documentation from it if it exists. 
 2. Determine which sub-command the user is executing: `render`, `compare`, `generate`, `validate`, or `inject`.
 3. Locate the `typ-glyph-tools.py` script provided by this plugin (relative to `~/.claude-plugin` or `tzander-skills/plugins/typ-glyph`).
-4. **Dependency Check:** Run `bash <script_path>/dependency-check.sh typ-glyph "PIL, cairosvg" Pillow cairosvg`. On success the script's last stdout line is `PLUGIN_PY=<path>` — capture that path and substitute its literal value for `<PLUGIN_PY>` in every subsequent step. On non-zero exit, report the stderr message to the user and stop. See the repo `CLAUDE.md`, section "Python Plugin Dependencies", for the pattern.
+4. **Dependency Check:** Run `bash <script_path>/dependency-check.sh typ-glyph "PIL, cairosvg" Pillow cairosvg`. On success the script's last stdout line is `PLUGIN_PY=<path>` — capture that path and substitute its literal value for `<PLUGIN_PY>` in every subsequent step. On non-zero exit, report the stderr message to the user and stop.
 
 ## The Sub-Commands
 

--- a/plugins/typ-glyph/scripts/dependency-check.sh
+++ b/plugins/typ-glyph/scripts/dependency-check.sh
@@ -11,8 +11,6 @@
 #          (3) create a user-local venv under $TMPDIR
 #          (4) verify — a post-install import failure usually means a native system
 #              library is missing (e.g., libcairo for cairosvg).
-#
-# See the repo CLAUDE.md, section "Python Plugin Dependencies", for rationale.
 
 if [ "$#" -lt 3 ]; then
     echo "usage: $0 <plugin-name> '<import-expr>' <package> [<package>...]" >&2


### PR DESCRIPTION
## Summary

- Plugin files must be self-contained at runtime — consumers install via the Claude Code marketplace into unrelated repos and don't have access to this marketplace repo's `CLAUDE.md` or `standards/CLAUDE.md`.
- Two dead references introduced in PR #83 pointed at "the repo CLAUDE.md, section 'Python Plugin Dependencies'". Removed both; the script's existing docstring already inlines the essential cascade rationale.

## Test plan

- [x] `bash plugins/typ-glyph/scripts/test_dependency-check.sh` — 12/12 pass (doc-only change, no behavioral impact)
- [ ] Manual: install the plugin in a fresh context and confirm no broken-pointer text is visible