### PR TITLE
Add --base argument to craft-pr for non-main PR targets

### DIFF
--- a/plugins/craft-pr/commands/craft-pr.md
+++ b/plugins/craft-pr/commands/craft-pr.md
@@ -27,7 +27,18 @@ If the user's input is ambiguous — e.g., a bare word that could be either a br
 
 Resolve this to a concrete branch name `<base>`. Substitute the literal value everywhere `<base>` appears below (do not type `<base>` into the shell verbatim).
 
-Verify the base exists on the remote: `git ls-remote --exit-code --heads origin <base> >/dev/null`. If the command exits non-zero, stop and tell the user: `Base branch '<base>' does not exist on 'origin'. Verify the branch name or push it first.`
+Verify the base exists on the remote:
+
+```bash
+git ls-remote --exit-code --heads origin <base> >/dev/null 2>/tmp/ls-remote-err.$$
+echo "exit=$?"
+```
+
+Check the reported exit code:
+
+- `0` — the base exists; continue.
+- `2` — the branch is not present on `origin`. Stop and tell the user: `Base branch '<base>' does not exist on 'origin'. Verify the branch name or push it first.`
+- Any other non-zero (typically `128`) — `git` could not reach `origin` (network/auth failure). Read `/tmp/ls-remote-err.$$` and surface the diagnostic to the user: `Could not verify base branch '<base>' on 'origin' (git ls-remote exit N): <stderr contents>. Check your network connection and authentication.` Then stop.
 
 ## Step 1: Gather Context
 

--- a/plugins/craft-pr/commands/craft-pr.md
+++ b/plugins/craft-pr/commands/craft-pr.md
@@ -5,25 +5,40 @@ description: Generate a PR title and description, optionally creating the PR on 
 disable-model-invocation: true
 allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion, WebFetch
 user-input: optional
-argument-hint: "[--create] [--draft]"
+argument-hint: "[--base <branch>] [--create] [--draft]"
 ---
 
-You are generating a pull request title and description for the current branch compared to origin/main. The title will appear in release notes, so it must be precise and meaningful to someone who hasn't seen the code.
+You are generating a pull request title and description for the current branch compared to a base branch (default: `main`). The title will appear in release notes, so it must be precise and meaningful to someone who hasn't seen the code.
 
 **If the user provided `--create` as input, you will push the branch to origin and create the PR after crafting it.** Otherwise, only output the title and description for the user to copy.
 
 **If the user provided `--draft` alongside `--create`, create the PR as a draft.** The `--draft` flag is only meaningful with `--create` — if used without it, ignore it.
 
+## Step 0: Resolve the Base Branch
+
+Before anything else, determine the base (target) branch for the PR. Accept any of these forms the user may supply:
+
+- `--base <branch>` or `--base=<branch>`
+- `branch=<branch>` or `branch <branch>`
+- A single positional argument that clearly names a branch (contains `/`, matches a known branching pattern like `feature/*`, `release/*`, `hotfix/*`, or matches a branch visible on `origin`)
+- Conversational phrasing that explicitly names a target: "target feature/x", "against feature/x", "base is feature/x"
+
+If the user's input is ambiguous — e.g., a bare word that could be either a branch name or an unrelated argument — use AskUserQuestion to confirm the intended base branch rather than guessing. If no base is supplied, default to `main`.
+
+Resolve this to a concrete branch name `<base>`. Substitute the literal value everywhere `<base>` appears below (do not type `<base>` into the shell verbatim).
+
+Verify the base exists on the remote: `git ls-remote --exit-code --heads origin <base> >/dev/null`. If the command exits non-zero, stop and tell the user: `Base branch '<base>' does not exist on 'origin'. Verify the branch name or push it first.`
+
 ## Step 1: Gather Context
 
-**Run all of these in parallel:**
+**Run all of these in parallel** (substitute the resolved `<base>` from Step 0):
 
-1. Run `git fetch origin main && git log origin/main..HEAD --oneline` to see all commits on this branch.
-2. Run `git diff origin/main...HEAD --stat` to see the summary of changed files.
-3. Run `git diff -U10 origin/main...HEAD` to see the full diff with context.
+1. Run `git fetch origin <base> && git log origin/<base>..HEAD --oneline` to see all commits on this branch.
+2. Run `git diff origin/<base>...HEAD --stat` to see the summary of changed files.
+3. Run `git diff -U10 origin/<base>...HEAD` to see the full diff with context.
 4. Run `git branch --show-current` to get the branch name.
 
-If there are no commits ahead of origin/main, stop immediately and tell the user: "No changes found compared to origin/main. Make sure you're on a feature branch with commits."
+If there are no commits ahead of `origin/<base>`, stop immediately and tell the user: "No changes found compared to origin/<base>. Make sure you're on a feature branch with commits."
 
 ## Step 2: Analyze the Changes
 
@@ -203,16 +218,16 @@ If the script was not found in 7a, stop and tell the user: "Could not locate `cr
 **Important:** Shell state does not persist between Bash tool calls. Use the literal paths printed by Step 7a — do not rely on shell variables.
 
 ```bash
-bash "<script-path>" --title "<title>" --body-file "<body-file-path>" [--draft]
+bash "<script-path>" --title "<title>" --body-file "<body-file-path>" --base "<base>" [--draft]
 ```
 
-If the user passed `--draft`, include the `--draft` flag.
+Always pass `--base "<base>"` with the resolved value from Step 0 (even when it is `main`) — this keeps the command and script in lockstep if defaults ever diverge. If the user passed `--draft`, include the `--draft` flag.
 
 ### 7c: Handle the result
 
 - **Exit code 0** — PR created successfully. Report the URL from the script output.
-- **Exit code 2** — Uncommitted changes detected. The body file was preserved. Use AskUserQuestion to ask the user whether to proceed (the remote will not include uncommitted changes). If yes, re-run the script with `--skip-dirty-check` and the **same `--body-file` path**:
+- **Exit code 2** — Uncommitted changes detected. The body file was preserved. Use AskUserQuestion to ask the user whether to proceed (the remote will not include uncommitted changes). If yes, re-run the script with `--skip-dirty-check` and the **same `--body-file` path** (and the same `--base`/`--draft` flags as before):
   ```bash
-  bash "<script-path>" --title "<title>" --body-file "<body-file-path>" --skip-dirty-check [--draft]
+  bash "<script-path>" --title "<title>" --body-file "<body-file-path>" --skip-dirty-check --base "<base>" [--draft]
   ```
 - **Any other exit code** — An error occurred. Report the error message from the script output.

--- a/plugins/craft-pr/scripts/create-pr.sh
+++ b/plugins/craft-pr/scripts/create-pr.sh
@@ -48,14 +48,17 @@ if [[ ! -f "$BODY_FILE" ]]; then
 fi
 
 # ── Cleanup ──────────────────────────────────────────────────────────
-# Always clean up the body temp file on exit, EXCEPT when exiting with
-# code 2 (dirty worktree) — the caller may re-invoke with --skip-dirty-check.
+# Always clean up temp files on exit, EXCEPT when exiting with code 2
+# (dirty worktree) — the caller may re-invoke with --skip-dirty-check
+# and needs the body file preserved.
 
 KEEP_BODY=false
+LS_REMOTE_ERR=""
 cleanup() {
     if [[ "$KEEP_BODY" == false ]]; then
         rm -f "$BODY_FILE"
     fi
+    [[ -n "$LS_REMOTE_ERR" ]] && rm -f "$LS_REMOTE_ERR"
 }
 trap cleanup EXIT
 
@@ -107,10 +110,8 @@ LS_REMOTE_RC=$?
 set -e
 case "$LS_REMOTE_RC" in
     0)
-        rm -f "$LS_REMOTE_ERR"
         ;;
     2)
-        rm -f "$LS_REMOTE_ERR"
         echo "Error: Base branch '$BASE' does not exist on 'origin'." >&2
         echo "Verify the branch name or push it to the remote first." >&2
         exit 1
@@ -118,10 +119,10 @@ case "$LS_REMOTE_RC" in
     *)
         echo "Error: Could not verify base branch '$BASE' on 'origin' (git ls-remote exit $LS_REMOTE_RC):" >&2
         cat "$LS_REMOTE_ERR" >&2
-        rm -f "$LS_REMOTE_ERR"
         exit 1
         ;;
 esac
+# LS_REMOTE_ERR is cleaned by the EXIT trap
 
 # ── Pre-flight checks ───────────────────────────────────────────────
 

--- a/plugins/craft-pr/scripts/create-pr.sh
+++ b/plugins/craft-pr/scripts/create-pr.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # title and description.
 #
 # Usage:
-#   bash create-pr.sh --title "PR title" --body-file /tmp/body.md [--draft] [--skip-dirty-check]
+#   bash create-pr.sh --title "PR title" --body-file /tmp/body.md [--base <branch>] [--draft] [--skip-dirty-check]
 #
 # Exit codes:
 #   0 — PR created successfully
@@ -17,6 +17,7 @@ set -euo pipefail
 
 TITLE=""
 BODY_FILE=""
+BASE="main"
 DRAFT=false
 SKIP_DIRTY_CHECK=false
 
@@ -24,6 +25,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --title)            TITLE="$2"; shift 2 ;;
         --body-file)        BODY_FILE="$2"; shift 2 ;;
+        --base)             BASE="$2"; shift 2 ;;
         --draft)            DRAFT=true; shift ;;
         --skip-dirty-check) SKIP_DIRTY_CHECK=true; shift ;;
         *)                  echo "Error: Unknown argument: $1" >&2; exit 1 ;;
@@ -88,6 +90,39 @@ if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
     exit 1
 fi
 
+if [[ "$BRANCH" == "$BASE" ]]; then
+    echo "Error: Current branch ('$BRANCH') is the same as the base branch. Check out a different branch before creating a PR." >&2
+    exit 1
+fi
+
+# ── Base branch exists on remote ────────────────────────────────────
+# git ls-remote --exit-code returns 2 when the ref is not found, and
+# other non-zero codes (typically 128) for network/auth failures. Split
+# these so offline users don't see a misleading "branch not found."
+
+LS_REMOTE_ERR=$(mktemp)
+set +e
+git ls-remote --exit-code --heads origin "$BASE" >/dev/null 2>"$LS_REMOTE_ERR"
+LS_REMOTE_RC=$?
+set -e
+case "$LS_REMOTE_RC" in
+    0)
+        rm -f "$LS_REMOTE_ERR"
+        ;;
+    2)
+        rm -f "$LS_REMOTE_ERR"
+        echo "Error: Base branch '$BASE' does not exist on 'origin'." >&2
+        echo "Verify the branch name or push it to the remote first." >&2
+        exit 1
+        ;;
+    *)
+        echo "Error: Could not verify base branch '$BASE' on 'origin' (git ls-remote exit $LS_REMOTE_RC):" >&2
+        cat "$LS_REMOTE_ERR" >&2
+        rm -f "$LS_REMOTE_ERR"
+        exit 1
+        ;;
+esac
+
 # ── Pre-flight checks ───────────────────────────────────────────────
 
 if [[ "$PLATFORM" == "github" ]]; then
@@ -100,7 +135,7 @@ if [[ "$PLATFORM" == "github" ]]; then
         exit 1
     }
 
-    EXISTING_PR=$(gh pr list --head "$BRANCH" --base main --state open --json url --jq '.[0].url' 2>/dev/null || true)
+    EXISTING_PR=$(gh pr list --head "$BRANCH" --base "$BASE" --state open --json url --jq '.[0].url' 2>/dev/null || true)
     if [[ -n "$EXISTING_PR" ]]; then
         echo "Error: A PR already exists for this branch: $EXISTING_PR" >&2
         echo "Use 'gh pr edit' to update it." >&2
@@ -121,7 +156,7 @@ elif [[ "$PLATFORM" == "azdo" ]]; then
         exit 1
     }
 
-    EXISTING_PR=$(az repos pr list --detect --source-branch "$BRANCH" --target-branch main --status active --query '[0].pullRequestId' -o tsv 2>/dev/null || true)
+    EXISTING_PR=$(az repos pr list --detect --source-branch "$BRANCH" --target-branch "$BASE" --status active --query '[0].pullRequestId' -o tsv 2>/dev/null || true)
     if [[ -n "$EXISTING_PR" ]]; then
         echo "Error: A PR already exists for this branch (ID: $EXISTING_PR)." >&2
         echo "Use 'az repos pr update --id $EXISTING_PR' to update it." >&2
@@ -149,14 +184,14 @@ git push -u origin HEAD || {
 # ── Create PR ────────────────────────────────────────────────────────
 
 if [[ "$PLATFORM" == "github" ]]; then
-    GH_ARGS=(gh pr create --base main --title "$TITLE" --body-file "$BODY_FILE")
+    GH_ARGS=(gh pr create --base "$BASE" --title "$TITLE" --body-file "$BODY_FILE")
     if [[ "$DRAFT" == true ]]; then
         GH_ARGS+=(--draft)
     fi
     "${GH_ARGS[@]}"
 
 elif [[ "$PLATFORM" == "azdo" ]]; then
-    AZ_ARGS=(az repos pr create --detect --target-branch main --title "$TITLE")
+    AZ_ARGS=(az repos pr create --detect --target-branch "$BASE" --title "$TITLE")
     if [[ "$DRAFT" == true ]]; then
         AZ_ARGS+=(--draft true)
     fi

--- a/plugins/craft-pr/scripts/test_create-pr.sh
+++ b/plugins/craft-pr/scripts/test_create-pr.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Smoke test for create-pr.sh.
+# Runs a small set of scenarios and asserts exit code + stderr pattern.
+# Invoke: bash scripts/test_create-pr.sh
+#
+# Coverage: syntax, usage errors, platform detection, branch-safety
+# guards, base-branch existence check. NOT covered: push, gh/az API
+# calls, or the GitHub/ADO happy paths — those require authenticated
+# tooling and network access; test them manually when touching the
+# pre-flight or PR-create sections.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$SCRIPT_DIR/create-pr.sh"
+
+fail=0
+pass=0
+
+TEST_TMPDIR=""
+trap 'if [ -n "$TEST_TMPDIR" ]; then rm -rf "$TEST_TMPDIR"; fi' EXIT
+
+assert_exit() {
+    local want="$1" got="$2" label="$3"
+    if [ "$want" = "$got" ]; then
+        pass=$((pass + 1))
+        echo "  PASS $label"
+    else
+        fail=$((fail + 1))
+        echo "  FAIL $label: want exit $want, got $got"
+    fi
+}
+
+assert_contains() {
+    local needle="$1" out="$2" label="$3"
+    case "$out" in
+        *"$needle"*) pass=$((pass + 1)); echo "  PASS $label" ;;
+        *) fail=$((fail + 1)); echo "  FAIL $label: output missing '$needle'"; echo "    got: $out" ;;
+    esac
+}
+
+# Create a working repo + bare "origin" pair. The bare path contains
+# "github.com" so the script classifies PLATFORM=github; ls-remote works
+# against the local bare repo, letting us exercise the base-exists check
+# without network access.
+setup_repo() {
+    local base="$1"
+    local bare="$base/test-github.com-fake.git"
+    local work="$base/work"
+    git init --bare --initial-branch=main "$bare" >/dev/null 2>&1
+    git init --initial-branch=main "$work" >/dev/null 2>&1
+    (
+        cd "$work"
+        git config user.email "test@example.com"
+        git config user.name "Test"
+        git config commit.gpgsign false
+        git config core.autocrlf false
+        echo hello > README
+        git add README
+        git commit -m "init" >/dev/null 2>&1
+        git remote add origin "$bare"
+        git push -u origin main >/dev/null 2>&1
+    )
+    echo "$work"
+}
+
+make_body() {
+    local f
+    f="$(mktemp)"
+    echo "body" > "$f"
+    echo "$f"
+}
+
+TEST_TMPDIR="$(mktemp -d)"
+
+echo "1) script is syntactically valid bash"
+if bash -n "$SCRIPT"; then
+    pass=$((pass + 1)); echo "  PASS bash -n parses the script"
+else
+    fail=$((fail + 1)); echo "  FAIL bash -n reported a syntax error"
+fi
+
+echo "2) --title is required"
+out=$(bash "$SCRIPT" 2>&1); rc=$?
+assert_exit 1 "$rc" "exit 1 when --title missing"
+assert_contains "--title is required" "$out" "usage message surfaced"
+
+echo "3) --body-file is required"
+out=$(bash "$SCRIPT" --title "t" 2>&1); rc=$?
+assert_exit 1 "$rc" "exit 1 when --body-file missing"
+assert_contains "--body-file is required" "$out" "usage message surfaced"
+
+echo "4) body file must exist"
+out=$(bash "$SCRIPT" --title "t" --body-file "$TEST_TMPDIR/nonexistent" 2>&1); rc=$?
+assert_exit 1 "$rc" "exit 1 when body file missing"
+assert_contains "Body file not found" "$out" "not-found message surfaced"
+
+echo "5) unknown flag rejected"
+B=$(make_body)
+out=$(bash "$SCRIPT" --title "t" --body-file "$B" --bogus 2>&1); rc=$?
+assert_exit 1 "$rc" "exit 1 on unknown arg"
+assert_contains "Unknown argument" "$out" "unknown-arg message surfaced"
+rm -f "$B"
+
+echo "6) no origin remote"
+B=$(make_body)
+EMPTY_REPO="$TEST_TMPDIR/empty-repo"
+git init --initial-branch=main "$EMPTY_REPO" >/dev/null 2>&1
+out=$(cd "$EMPTY_REPO" && bash "$SCRIPT" --title "t" --body-file "$B" 2>&1); rc=$?
+assert_exit 1 "$rc" "exit 1 when origin missing"
+assert_contains "No 'origin' remote" "$out" "missing-origin message surfaced"
+rm -f "$B"
+
+echo "7) unrecognized hosting platform"
+B=$(make_body)
+PLAIN_REPO="$TEST_TMPDIR/plain-repo"
+git init --initial-branch=main "$PLAIN_REPO" >/dev/null 2>&1
+(cd "$PLAIN_REPO" && git remote add origin "$TEST_TMPDIR/not-a-real-host.git")
+out=$(cd "$PLAIN_REPO" && bash "$SCRIPT" --title "t" --body-file "$B" 2>&1); rc=$?
+assert_exit 1 "$rc" "exit 1 on unrecognized platform"
+assert_contains "Could not determine hosting platform" "$out" "platform diagnostic surfaced"
+rm -f "$B"
+
+echo "8) refuses to push from main"
+B=$(make_body)
+REPO=$(setup_repo "$TEST_TMPDIR/r8")
+out=$(cd "$REPO" && bash "$SCRIPT" --title "t" --body-file "$B" 2>&1); rc=$?
+assert_exit 1 "$rc" "exit 1 when on main"
+assert_contains "Refusing to push to 'main'" "$out" "refuse-main diagnostic surfaced"
+rm -f "$B"
+
+echo "9) refuses when current branch equals base"
+B=$(make_body)
+REPO=$(setup_repo "$TEST_TMPDIR/r9")
+(cd "$REPO" && git checkout -b feat/x >/dev/null 2>&1)
+out=$(cd "$REPO" && bash "$SCRIPT" --title "t" --body-file "$B" --base feat/x 2>&1); rc=$?
+assert_exit 1 "$rc" "exit 1 when branch equals base"
+assert_contains "same as the base branch" "$out" "same-branch diagnostic surfaced"
+rm -f "$B"
+
+echo "10) base branch must exist on origin"
+B=$(make_body)
+REPO=$(setup_repo "$TEST_TMPDIR/r10")
+(cd "$REPO" && git checkout -b feat/y >/dev/null 2>&1)
+out=$(cd "$REPO" && bash "$SCRIPT" --title "t" --body-file "$B" --base nonexistent-xyz 2>&1); rc=$?
+assert_exit 1 "$rc" "exit 1 when base missing on remote"
+assert_contains "does not exist on 'origin'" "$out" "missing-base diagnostic surfaced"
+rm -f "$B"
+
+echo
+echo "passed: $pass, failed: $fail"
+[ "$fail" -eq 0 ]

--- a/plugins/craft-pr/scripts/test_create-pr.sh
+++ b/plugins/craft-pr/scripts/test_create-pr.sh
@@ -39,36 +39,74 @@ assert_contains() {
     esac
 }
 
-# Create a working repo + bare "origin" pair. The bare path contains
-# "github.com" so the script classifies PLATFORM=github; ls-remote works
-# against the local bare repo, letting us exercise the base-exists check
-# without network access.
+# Create a working repo + bare "origin" pair. The bare path contains a
+# platform marker ("github.com" by default; pass "dev.azure.com" to
+# exercise the ADO branch) so the script classifies PLATFORM correctly;
+# ls-remote works against the local bare repo, letting us exercise the
+# base-exists check without network access.
+#
+# Any git failure during setup is reported to stderr and returns non-zero
+# so tests don't silently run against a half-built fixture.
 setup_repo() {
     local base="$1"
-    local bare="$base/test-github.com-fake.git"
+    local marker="${2:-github.com}"
+    local bare="$base/test-${marker}-fake.git"
     local work="$base/work"
-    git init --bare --initial-branch=main "$bare" >/dev/null 2>&1
-    git init --initial-branch=main "$work" >/dev/null 2>&1
-    (
+    if ! git init --bare --initial-branch=main "$bare" >/dev/null 2>&1; then
+        echo "setup_repo: git init --bare failed for $bare" >&2
+        return 1
+    fi
+    if ! git init --initial-branch=main "$work" >/dev/null 2>&1; then
+        echo "setup_repo: git init failed for $work" >&2
+        return 1
+    fi
+    if ! (
+        set -e
         cd "$work"
         git config user.email "test@example.com"
         git config user.name "Test"
         git config commit.gpgsign false
         git config core.autocrlf false
+        # Opt out of the global pre-push hook that blocks pushes to main;
+        # this test fixture legitimately pushes main to its own local bare
+        # "origin". See ~/.git-hooks/pre-push for the opt-out mechanism.
+        touch .allow-push-main
         echo hello > README
         git add README
         git commit -m "init" >/dev/null 2>&1
         git remote add origin "$bare"
         git push -u origin main >/dev/null 2>&1
-    )
+    ); then
+        echo "setup_repo: workdir setup failed for $work" >&2
+        return 1
+    fi
     echo "$work"
 }
 
+# Create a body tmp file inside TEST_TMPDIR so the EXIT trap cleans it
+# up even if a test aborts. Using TMPDIR=... keeps the call portable
+# across GNU and BSD mktemp (which disagree on the -p flag).
 make_body() {
     local f
-    f="$(mktemp)"
+    f="$(TMPDIR="$TEST_TMPDIR" mktemp)"
     echo "body" > "$f"
     echo "$f"
+}
+
+# Guard against a footgun: on Git Bash, `cd ""` silently stays put
+# rather than erroring. If setup_repo ever returns empty (e.g., a
+# silent git failure), `(cd "$REPO" && git checkout ...)` would then
+# run the checkout in the REAL repo containing this test, leaking
+# branches into the developer's worktree. require_repo aborts the
+# specific test cleanly instead.
+require_repo() {
+    local repo="$1" label="$2"
+    if [ -z "$repo" ]; then
+        fail=$((fail + 1))
+        echo "  FAIL $label: setup_repo returned empty path (skipping test)"
+        return 1
+    fi
+    return 0
 }
 
 TEST_TMPDIR="$(mktemp -d)"
@@ -114,37 +152,86 @@ rm -f "$B"
 echo "7) unrecognized hosting platform"
 B=$(make_body)
 PLAIN_REPO="$TEST_TMPDIR/plain-repo"
-git init --initial-branch=main "$PLAIN_REPO" >/dev/null 2>&1
-(cd "$PLAIN_REPO" && git remote add origin "$TEST_TMPDIR/not-a-real-host.git")
-out=$(cd "$PLAIN_REPO" && bash "$SCRIPT" --title "t" --body-file "$B" 2>&1); rc=$?
-assert_exit 1 "$rc" "exit 1 on unrecognized platform"
-assert_contains "Could not determine hosting platform" "$out" "platform diagnostic surfaced"
+if ! git init --initial-branch=main "$PLAIN_REPO" >/dev/null 2>&1; then
+    fail=$((fail + 1)); echo "  FAIL test 7 setup: git init"
+elif ! (cd "$PLAIN_REPO" && git remote add origin "$TEST_TMPDIR/not-a-real-host.git"); then
+    fail=$((fail + 1)); echo "  FAIL test 7 setup: git remote add"
+else
+    out=$(cd "$PLAIN_REPO" && bash "$SCRIPT" --title "t" --body-file "$B" 2>&1); rc=$?
+    assert_exit 1 "$rc" "exit 1 on unrecognized platform"
+    assert_contains "Could not determine hosting platform" "$out" "platform diagnostic surfaced"
+fi
 rm -f "$B"
 
 echo "8) refuses to push from main"
 B=$(make_body)
 REPO=$(setup_repo "$TEST_TMPDIR/r8")
-out=$(cd "$REPO" && bash "$SCRIPT" --title "t" --body-file "$B" 2>&1); rc=$?
-assert_exit 1 "$rc" "exit 1 when on main"
-assert_contains "Refusing to push to 'main'" "$out" "refuse-main diagnostic surfaced"
+if require_repo "$REPO" "test 8"; then
+    out=$(cd "$REPO" && bash "$SCRIPT" --title "t" --body-file "$B" 2>&1); rc=$?
+    assert_exit 1 "$rc" "exit 1 when on main"
+    assert_contains "Refusing to push to 'main'" "$out" "refuse-main diagnostic surfaced"
+fi
 rm -f "$B"
 
 echo "9) refuses when current branch equals base"
 B=$(make_body)
 REPO=$(setup_repo "$TEST_TMPDIR/r9")
-(cd "$REPO" && git checkout -b feat/x >/dev/null 2>&1)
-out=$(cd "$REPO" && bash "$SCRIPT" --title "t" --body-file "$B" --base feat/x 2>&1); rc=$?
-assert_exit 1 "$rc" "exit 1 when branch equals base"
-assert_contains "same as the base branch" "$out" "same-branch diagnostic surfaced"
+if require_repo "$REPO" "test 9"; then
+    (cd "$REPO" && git checkout -b feat/x >/dev/null 2>&1)
+    out=$(cd "$REPO" && bash "$SCRIPT" --title "t" --body-file "$B" --base feat/x 2>&1); rc=$?
+    assert_exit 1 "$rc" "exit 1 when branch equals base"
+    assert_contains "same as the base branch" "$out" "same-branch diagnostic surfaced"
+fi
 rm -f "$B"
 
 echo "10) base branch must exist on origin"
 B=$(make_body)
 REPO=$(setup_repo "$TEST_TMPDIR/r10")
-(cd "$REPO" && git checkout -b feat/y >/dev/null 2>&1)
-out=$(cd "$REPO" && bash "$SCRIPT" --title "t" --body-file "$B" --base nonexistent-xyz 2>&1); rc=$?
-assert_exit 1 "$rc" "exit 1 when base missing on remote"
-assert_contains "does not exist on 'origin'" "$out" "missing-base diagnostic surfaced"
+if require_repo "$REPO" "test 10"; then
+    (cd "$REPO" && git checkout -b feat/y >/dev/null 2>&1)
+    out=$(cd "$REPO" && bash "$SCRIPT" --title "t" --body-file "$B" --base nonexistent-xyz 2>&1); rc=$?
+    assert_exit 1 "$rc" "exit 1 when base missing on remote"
+    assert_contains "does not exist on 'origin'" "$out" "missing-base diagnostic surfaced"
+fi
+rm -f "$B"
+
+echo "11) ls-remote network/auth failure distinguished from missing branch"
+B=$(make_body)
+REPO=$(setup_repo "$TEST_TMPDIR/r11")
+if require_repo "$REPO" "test 11"; then
+    # Point origin at a nonexistent bare path (keeping "github.com" in the URL
+    # so platform detection still classifies as GitHub). ls-remote will exit
+    # with code 128 (fatal: not a git repository), exercising the *) branch.
+    (cd "$REPO" && git checkout -b feat/z >/dev/null 2>&1 \
+        && git remote set-url origin "$TEST_TMPDIR/bogus-github.com-nope.git")
+    out=$(cd "$REPO" && bash "$SCRIPT" --title "t" --body-file "$B" --base main 2>&1); rc=$?
+    assert_exit 1 "$rc" "exit 1 on ls-remote non-2 failure"
+    assert_contains "Could not verify base branch" "$out" "network-failure diagnostic surfaced"
+    # "fatal:" is how git prefixes its own error messages — presence proves
+    # we relayed git's stderr rather than just printing our own wrapper.
+    assert_contains "fatal:" "$out" "underlying git stderr surfaced"
+fi
+rm -f "$B"
+
+echo "12) ADO platform classified from dev.azure.com URL"
+B=$(make_body)
+REPO=$(setup_repo "$TEST_TMPDIR/r12" "dev.azure.com")
+if require_repo "$REPO" "test 12"; then
+    (cd "$REPO" && git checkout -b feat/ado >/dev/null 2>&1)
+    # Current branch equals base, so we reach the branch-equals-base guard
+    # (which fires AFTER platform detection). A success here proves the
+    # dev.azure.com URL was recognized and the script didn't bail with
+    # "Could not determine hosting platform."
+    out=$(cd "$REPO" && bash "$SCRIPT" --title "t" --body-file "$B" --base feat/ado 2>&1); rc=$?
+    assert_exit 1 "$rc" "exit 1 on ADO path"
+    assert_contains "same as the base branch" "$out" "ADO path reaches branch-equals-base guard"
+    case "$out" in
+        *"Could not determine hosting platform"*)
+            fail=$((fail + 1)); echo "  FAIL ADO URL misclassified as unknown platform" ;;
+        *)
+            pass=$((pass + 1)); echo "  PASS ADO URL classified correctly" ;;
+    esac
+fi
 rm -f "$B"
 
 echo


### PR DESCRIPTION
## Summary

Resolves #104. Threads a resolved base branch through both the `craft-pr` command and `create-pr.sh` so PRs can target branches other than `main` — e.g. long-lived feature branches like `feature/UmbracoGCv17` where child branches merge back into the feature rather than into `main`. Default behavior is unchanged (falls back to `main` when no base is specified).

## Changes

- **`plugins/craft-pr/scripts/create-pr.sh`** — New `--base <branch>` flag (default `main`) used in the existing-PR check, `gh pr create --base`, and `az repos pr create --target-branch`. Added a guard that refuses to create a PR when the current branch equals the base, and an `ls-remote` pre-flight that verifies the base exists on `origin`. The verification distinguishes exit code 2 (branch missing) from other non-zero exits (network/auth failures), so offline users don't see a misleading "branch not found" message.
- **`plugins/craft-pr/commands/craft-pr.md`** — New Step 0 resolves the base from `--base <branch>`, `branch=<branch>`, a positional argument, or conversational phrasing. Uses `AskUserQuestion` when the intent is ambiguous rather than guessing. All `origin/main` references in Step 1's diffing and commit-listing now substitute the resolved `<base>`. Step 7b always forwards `--base` to the script.
- **`plugins/craft-pr/scripts/test_create-pr.sh`** — New smoke test (19 assertions) covering syntax, all usage errors, missing origin, unrecognized platform, main-branch refusal, branch-equals-base, and missing-base-on-remote. Follows the existing `typ-glyph/scripts/test_dependency-check.sh` pattern.

## Gotchas

- The base-existence check adds one `git ls-remote` round trip (~500ms on typical connections) per `--create` invocation. Acceptable given the flow already requires `git push` and a PR-create API call.
- Default fallback remains hardcoded `main`, matching prior behavior. Detecting the repo's actual default branch (e.g., via `gh repo view --json defaultBranchRef`) is out of scope for this issue.
- Tests do not exercise the push or `gh`/`az` API paths — those require authenticated tooling and network access. Verify those manually when editing the pre-flight or PR-create sections.

## Test Cases

- [x] `--base <branch>` threads into `gh pr create --base` and `az repos pr create --target-branch` (code inspection + manual smoke)
- [x] Script exits 1 with "same as the base branch" when `BRANCH == BASE`
- [x] Script exits 1 with "does not exist on 'origin'" when `--base` names a missing branch
- [x] Script exits 1 with the underlying git stderr when `ls-remote` fails with a non-2 exit code (network/auth failure)
- [x] Default path (no `--base`) still resolves to `main` and reaches the dirty-check / push phase
- [x] All usage-error paths (missing `--title`, missing `--body-file`, nonexistent body file, unknown flag, missing origin, unrecognized platform) exit 1 with the expected diagnostic
- [ ] Happy-path PR creation against a non-`main` base on GitHub (requires manual verification with real auth)
- [ ] Happy-path PR creation against a non-`main` base on Azure DevOps (requires manual verification with real auth)