### PR TITLE
Fix #97: route self-review findings by scope, not artifact type

### DIFF
--- a/plugins/self-review/commands/self-review.md
+++ b/plugins/self-review/commands/self-review.md
@@ -23,15 +23,34 @@ You are a meta-learning agent analyzing the current development session. Your ta
   Use `ENDOFBODY` (not `EOF`) to avoid early termination when the body itself contains shell examples with `EOF`.
 
 ## Output Format & Actions
-First, silently reflect on your immediate memory of the latest prompts, bugs, and workflows in the session. Present your findings grouped into these three categories. If a category yields no findings, state so.
+First, silently reflect on your immediate memory of the latest prompts, bugs, and workflows in the session. Present your findings grouped into the three categories below. If a category yields no findings, state so.
+
+**Route by scope, not artifact.** Categories 1 and 2 can produce the same artifact type (a CLAUDE.md text block) — what differs is the **scope** of the rule and therefore the **delivery path**:
+
+- **Category 1 (repo-specific):** rule applies only to this repo's code, architecture, CI, or operations → direct edit of this repo's `CLAUDE.md` → commit + PR through the normal repo workflow.
+- **Category 2 (generic):** rule is a workflow pattern, tooling convention, or engineering practice that would apply across any project the user works on → file a GitHub issue on `TimZander/claude` → merged into `standards/CLAUDE.md` → synced to each developer's `~/.claude/CLAUDE.md` on the next sync run.
+
+**Decision rule — before routing anything to category 1, ask:** *"Would a developer working on a completely different project in a different language also benefit from this rule?"* If yes, it belongs in category 2. When in doubt, prefer category 2 — team standards sync out to every repo, so generic rules still cover this repo's future work.
+
+**Never edit `~/.claude/CLAUDE.md` directly** — it is a derived artifact that the sync script overwrites. Team-wide rules go to `standards/CLAUDE.md` in `TimZander/claude` via a GitHub issue (category 2).
+
+Example routings:
+
+| Directive | Category | Reason |
+|---|---|---|
+| "When querying this app's App Insights, use the active ID from the connection string" | 1 | Specific to this app's Azure setup |
+| "Always write pasted logs > 100 lines to a scratch file before analysis" | 2 | Generic workflow rule |
+| "This project's CI runs migrations before tests; expect failures if you skip the migration step" | 1 | Specific to this project's CI pipeline |
+| "When correlating client and server logs, always normalize to UTC first" | 2 | Universal engineering practice |
+| "This project's service layer uses singletons; consider thread safety" | 1 | Architectural fact about this codebase |
 
 ### 1. Repo-specific learning
-- **Trigger:** We lacked documentation or explicit instructions in the repository context to do the work seamlessly.
+- **Trigger:** We lacked repo-specific documentation — facts about this project's code, architecture, CI, or operations — needed to do the work seamlessly.
 - **Action:** Propose appending an exact text block or documentation rule to the **current repository's** `CLAUDE.md` file. Provide exactly what text you will insert.
 
 ### 2. Team-wide improvement
-- **Trigger:** We hit CI flakiness, deployment issues, cross-project pain points, or general workflow friction.
-- **Action:** Propose creating a GitHub issue. This issue must be explicitly created on the `TimZander/claude` repository (`gh issue create --repo TimZander/claude`). Format the proposal mimicking the `/improve-stories` style (Markdown structure, clear goals, acceptance criteria).
+- **Trigger:** We hit CI flakiness, deployment issues, cross-project pain points, general workflow friction, or identified a CLAUDE.md directive (workflow rule, naming convention, tooling pattern, etc.) that would apply across multiple repos.
+- **Action:** Propose creating a GitHub issue on `TimZander/claude` (`gh issue create --repo TimZander/claude`). When the finding is a generic CLAUDE.md directive, frame the issue as adding the rule to `standards/CLAUDE.md` (not to any individual repo's CLAUDE.md, and never to `~/.claude/CLAUDE.md` directly). Format the proposal mimicking the `/improve-stories` style (Markdown structure, clear goals, acceptance criteria).
 
 ### 3. Skill opportunity
 - **Trigger:** We performed repetitive, multi-step tool interactions that could be bundled into a new reusable plugin or command.

--- a/plugins/self-review/commands/self-review.md
+++ b/plugins/self-review/commands/self-review.md
@@ -27,18 +27,20 @@ First, silently reflect on your immediate memory of the latest prompts, bugs, an
 
 **Route by scope, not artifact.** Categories 1 and 2 can produce the same artifact type (a CLAUDE.md text block) — what differs is the **scope** of the rule and therefore the **delivery path**:
 
-- **Category 1 (repo-specific):** rule applies only to this repo's code, architecture, CI, or operations → direct edit of this repo's `CLAUDE.md` → commit + PR through the normal repo workflow.
-- **Category 2 (generic):** rule is a workflow pattern, tooling convention, or engineering practice that would apply across any project the user works on → file a GitHub issue on `TimZander/claude` → merged into `standards/CLAUDE.md` → synced to each developer's `~/.claude/CLAUDE.md` on the next sync run.
+- **Category 1 (repo-specific):** rule is primarily tied to this repo's code, architecture, CI, or operations (would not benefit a developer on a different project) → direct edit of this repo's `CLAUDE.md` → commit + PR through the normal repo workflow.
+- **Category 2 (generic):** rule is a workflow pattern, tooling convention, or engineering practice that would apply across any project the user works on → file a GitHub issue on `TimZander/claude`. Downstream, the issue is merged into `standards/CLAUDE.md` and lands in each developer's `~/.claude/CLAUDE.md` on their next `setup-env` run. **The skill's responsibility ends at filing the issue** — do not try to PR `standards/CLAUDE.md` or trigger the sync.
 
-**Decision rule — before routing anything to category 1, ask:** *"Would a developer working on a completely different project in a different language also benefit from this rule?"* If yes, it belongs in category 2. When in doubt, prefer category 2 — team standards sync out to every repo, so generic rules still cover this repo's future work.
+**Decision rule — before routing anything to category 1, ask:** *"Would a developer working on a completely different project in a different language also benefit from this rule?"* If yes, it belongs in category 2. When in doubt, prefer category 2 — team standards land in each developer's `~/.claude/CLAUDE.md` and apply to every repo they open, so generic rules still cover this repo's future work.
 
-**Never edit `~/.claude/CLAUDE.md` directly** — it is a derived artifact that the sync script overwrites. Team-wide rules go to `standards/CLAUDE.md` in `TimZander/claude` via a GitHub issue (category 2).
+**Split mixed findings.** If a directive has both generic and repo-specific components, split it: propose the generic rule for category 2 and the project-specific wrapper (e.g., "this repo's X uses the generic pattern Y in way Z") for category 1.
+
+**Never target `~/.claude/CLAUDE.md` as the destination for team-wide rules.** Its team-standards section (between the `<!-- TEAM-STANDARDS:... -->` markers) is replaced by the sync script (`setup-env.sh`/`.ps1`) on the next run. Personal additions outside the markers are preserved, but team-wide rules added there never reach other developers. Route them to `standards/CLAUDE.md` in `TimZander/claude` via a GitHub issue (category 2).
 
 Example routings:
 
 | Directive | Category | Reason |
 |---|---|---|
-| "When querying this app's App Insights, use the active ID from the connection string" | 1 | Specific to this app's Azure setup |
+| "This app's App Insights resource is `prod-web-ai-eastus` in subscription `<sub-id>` — use that when running NRQL locally" | 1 | Names concrete resources in this app's Azure setup |
 | "Always write pasted logs > 100 lines to a scratch file before analysis" | 2 | Generic workflow rule |
 | "This project's CI runs migrations before tests; expect failures if you skip the migration step" | 1 | Specific to this project's CI pipeline |
 | "When correlating client and server logs, always normalize to UTC first" | 2 | Universal engineering practice |
@@ -50,7 +52,7 @@ Example routings:
 
 ### 2. Team-wide improvement
 - **Trigger:** We hit CI flakiness, deployment issues, cross-project pain points, general workflow friction, or identified a CLAUDE.md directive (workflow rule, naming convention, tooling pattern, etc.) that would apply across multiple repos.
-- **Action:** Propose creating a GitHub issue on `TimZander/claude` (`gh issue create --repo TimZander/claude`). When the finding is a generic CLAUDE.md directive, frame the issue as adding the rule to `standards/CLAUDE.md` (not to any individual repo's CLAUDE.md, and never to `~/.claude/CLAUDE.md` directly). Format the proposal mimicking the `/improve-stories` style (Markdown structure, clear goals, acceptance criteria).
+- **Action:** Propose creating a GitHub issue on `TimZander/claude` (`gh issue create --repo TimZander/claude`). When the finding is a generic CLAUDE.md directive, frame the issue as adding the rule to `standards/CLAUDE.md`. Format the proposal mimicking the `/improve-stories` style (Markdown structure, clear goals, acceptance criteria).
 
 ### 3. Skill opportunity
 - **Trigger:** We performed repetitive, multi-step tool interactions that could be bundled into a new reusable plugin or command.


### PR DESCRIPTION
Fixes #97.

## Summary

- Add a "route by scope, not artifact" preamble to `plugins/self-review/commands/self-review.md` so generic workflow rules (e.g. "write pasted logs > 100 lines to a scratch file") get routed to category 2 — a GitHub issue on `TimZander/claude` destined for `standards/CLAUDE.md` — instead of being mis-appended to the current repo's `CLAUDE.md` just because the artifact happens to be a text block.
- Add an explicit decision rule ("would a developer on a completely different project also benefit?"), a "when in doubt, prefer category 2" tiebreaker, a split-findings rule for directives with both generic and repo-specific parts, and a 5-row examples table so the agent has concrete patterns to match against.
- Tighten category 1's trigger to "repo-specific documentation — facts about this project's code, architecture, CI, or operations", expand category 2's trigger to explicitly include CLAUDE.md directives that apply across multiple repos, and document that `~/.claude/CLAUDE.md`'s team-standards section is replaced between `<!-- TEAM-STANDARDS:... -->` markers on each `setup-env` run (so it must not be targeted for team-wide rules).

## Test plan

- [ ] Run `/self-review` on a session that surfaced a generic workflow rule (e.g. a pasted-log handling practice) and verify the proposed action is category 2, not category 1.
- [ ] Run `/self-review` on a session that surfaced a project-specific gotcha (e.g. "this repo's CI has X quirk") and verify the proposed action is category 1.
- [ ] Run `/self-review` on a mixed session and verify the proposed actions are correctly partitioned without follow-up disambiguation from the user.
- [ ] Verify the skill never proposes editing `~/.claude/CLAUDE.md` directly for team-wide rules.