### PR TITLE
Fix #95: add log timezone conventions to team standards

### DIFF
--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -188,6 +188,21 @@ When the user pastes a log longer than ~100 lines (device log, server log, CI lo
 
 The first-paste token cost is unavoidable, but every follow-up query avoids re-tokenizing the full paste.
 
+## Log Timezone Conventions
+
+When cross-referencing logs from multiple sources (client ↔ server, CI ↔ deploy target, monitoring ↔ application, etc.), **always normalize all timestamps to UTC before building a timeline or drawing causal conclusions.**
+
+Before using any timestamp from a log dump, explicitly identify its timezone:
+
+- **Server logs:** assume UTC unless proven otherwise.
+- **Client/device logs:** look for a timezone marker in the log itself (diagnostic context blocks, configuration dumps, log header metadata). If no marker is present, ask the user before proceeding — do not guess.
+- **CI logs:** check the CI runner's timezone setting (usually UTC, but some self-hosted runners differ).
+- **Application logs from libraries:** check the library's default (some log in local time, others in UTC).
+
+When reporting a correlated timeline back to the user, always label timestamps explicitly with their timezone (e.g. `22:35:14 UTC`, `16:35:14 MDT`) to avoid downstream ambiguity. Prefer UTC in final timelines; include local-time annotation only when it adds clarity (e.g. "business hours" reasoning).
+
+A common source of bug-report confusion is a user reporting an event time in their local timezone and a developer comparing it against server UTC without realizing the offset. Treat every user-reported time as local unless the user explicitly says "UTC".
+
 ## Troubleshooting Failures
 
 When a deployment, infrastructure operation, or third-party integration fails with an unexpected error:

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -194,14 +194,17 @@ When cross-referencing logs from multiple sources (client ↔ server, CI ↔ dep
 
 Before using any timestamp from a log dump, explicitly identify its timezone:
 
-- **Server logs:** assume UTC unless proven otherwise.
-- **Client/device logs:** look for a timezone marker in the log itself (diagnostic context blocks, configuration dumps, log header metadata). If no marker is present, ask the user before proceeding — do not guess.
+- **Server logs:** assume UTC for cloud-managed services (Azure/AWS/GCP); for on-prem servers (journald, Windows Event Log), check the host's timezone — defaults are typically server local time, not UTC.
+- **Client/device logs:** look for a timezone marker in the log itself — e.g., a line like `Timezone: America/Denver (UTC-0700)` in a diagnostic context block, a config dump header, or log metadata. If no marker is present, ask the user before proceeding — do not infer it from surrounding context.
 - **CI logs:** check the CI runner's timezone setting (usually UTC, but some self-hosted runners differ).
+- **Container/Kubernetes logs:** check the pod/container `TZ` env var (usually UTC but not guaranteed).
 - **Application logs from libraries:** check the library's default (some log in local time, others in UTC).
 
-When reporting a correlated timeline back to the user, always label timestamps explicitly with their timezone (e.g. `22:35:14 UTC`, `16:35:14 MDT`) to avoid downstream ambiguity. Prefer UTC in final timelines; include local-time annotation only when it adds clarity (e.g. "business hours" reasoning).
+When reporting a correlated timeline back to the user, always label timestamps explicitly with their timezone (e.g. `22:35:14 UTC`, `16:35:14 MDT (America/Denver)`) — pair common abbreviations with an IANA identifier when precision matters. Prefer UTC in final timelines; include local-time annotation only when it adds clarity (e.g. "business hours" reasoning).
 
 A common source of bug-report confusion is a user reporting an event time in their local timezone and a developer comparing it against server UTC without realizing the offset. Treat every user-reported time as local unless the user explicitly says "UTC".
+
+Combined with the scratch-file pattern above, timezone normalization becomes a step during extraction rather than a retrofit during correlation.
 
 ## Troubleshooting Failures
 


### PR DESCRIPTION
Fixes #95.

## Summary

- Add a new `## Log Timezone Conventions` section to `standards/CLAUDE.md`, placed between `## Pasted Log Handling` and `## Troubleshooting Failures` — the issue explicitly noted the two pair naturally (once logs are in scratch files, timezone normalization happens at extraction time rather than in-line during correlation).
- Directs Claude to normalize all timestamps to UTC before building a cross-source timeline, to identify each log source's timezone explicitly (ask the user when a client log has no marker rather than inferring), and to label timestamps with their timezone in correlated output — covering all four acceptance criteria from the issue.
- Source-by-source guidance splits the "Server logs" case into cloud-managed (UTC default) vs. on-prem (host TZ default), covers Container/Kubernetes `TZ` env vars, and shows a concrete timezone-marker example (`Timezone: America/Denver (UTC-0700)`) so the rule is actionable rather than abstract.

## Test plan

- [ ] Run `setup-env.sh` / `setup-env.ps1` on a developer machine and verify the new section appears in `~/.claude/CLAUDE.md` inside the `<!-- TEAM-STANDARDS:... -->` markers.
- [ ] In a session where a user pastes client and server logs with no timezone marker on the client side, confirm Claude asks about the client timezone before correlating, rather than assuming.
- [ ] In a session that produces a correlated cross-source timeline, confirm every timestamp in the output is labeled with its timezone (e.g. `22:35:14 UTC`, `16:35:14 MDT (America/Denver)`).
- [ ] Confirm Claude prefers UTC as the canonical representation in internal reasoning and converts incoming timestamps rather than mixing conventions within a single timeline.
- [ ] Negative check: on a single-source log analysis, confirm Claude does NOT over-prompt about timezone when only one timezone is in play.