### PR TITLE
Fix #98: add tfvc-search plugin for ADO TFVC investigation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -95,6 +95,14 @@
       "source": "./plugins/typ-glyph",
       "category": "development",
       "strict": false
+    },
+    {
+      "name": "tfvc-search",
+      "description": "Search and read Azure DevOps TFVC content (SQL schema scripts, etc.) via REST without a local workspace",
+      "author": { "name": "Tim Zander" },
+      "source": "./plugins/tfvc-search",
+      "category": "development",
+      "strict": false
     }
   ]
 }

--- a/plugins/tfvc-search/.claude-plugin/plugin.json
+++ b/plugins/tfvc-search/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tfvc-search",
-  "description": "Search and read Azure DevOps TFVC content (SQL schema, etc.) via REST without a local workspace",
+  "description": "Search and read Azure DevOps TFVC content (SQL schema scripts, etc.) via REST without a local workspace",
   "author": {
     "name": "Tim Zander"
   }

--- a/plugins/tfvc-search/.claude-plugin/plugin.json
+++ b/plugins/tfvc-search/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "tfvc-search",
+  "description": "Search and read Azure DevOps TFVC content (SQL schema, etc.) via REST without a local workspace",
+  "author": {
+    "name": "Tim Zander"
+  }
+}

--- a/plugins/tfvc-search/README.md
+++ b/plugins/tfvc-search/README.md
@@ -49,13 +49,16 @@ Consider documenting your mirror path and org/project defaults in your repo's `C
 
 ## Path-escaping note
 
-TFVC paths start with `$` and often contain spaces. Always single-quote them in Bash:
+TFVC paths start with `$` and often contain spaces. Two rules on Bash:
+
+1. **Always single-quote the path:** `'$/BGV Databases/RedGate/BGVTSWCustom'`. Double quotes will make the shell try to expand `$/…` as a variable.
+2. **On Git Bash / MSYS, always prefix the command with `MSYS_NO_PATHCONV=1`.** Without it, MSYS rewrites `'$/Foo/Bar'` into `'$C:/Program Files/Git/Foo/Bar'` before Python receives the arg, and ADO rejects the call. The variable is harmless on non-MSYS shells, so you can always include it.
 
 ```bash
---scope '$/BGV Databases/RedGate/BGVTSWCustom'
+MSYS_NO_PATHCONV=1 python tfvc-search.py ls \
+  --org bgvone --project "BGV Databases" \
+  --scope '$/BGV Databases/RedGate/BGVTSWCustom'
 ```
-
-Double quotes will make the shell try to expand `$/…` as a variable.
 
 ## Scope (v1)
 

--- a/plugins/tfvc-search/README.md
+++ b/plugins/tfvc-search/README.md
@@ -37,9 +37,22 @@ python path/to/tfvc-search.py ls \
 
 ## Optional: local mirror
 
-If your team keeps a read-only local mirror of the TFVC subtree (e.g. `C:/temp/bgvtsw-tfvc-readonly/`), pass `--mirror` and `--mirror-prefix` together. When the mirror covers the full scope, the skill skips REST and walks the filesystem — orders of magnitude faster and works offline. On a per-file basis, `read` also prefers the mirror.
+If your team keeps a read-only local mirror of the TFVC subtree (e.g. `C:/temp/bgvtsw-tfvc-readonly/`), the skill can use it automatically instead of REST — orders of magnitude faster, works offline, and avoids any org policy against reaching live TFVC during investigation.
 
-Consider documenting your mirror path and org/project defaults in your repo's `CLAUDE.md` so the skill picks them up automatically.
+**Setup (one-time):** add a `## TFVC Mirror` block to your `~/.claude/CLAUDE.md` with your mirror path and the TFVC scope it mirrors. The skill's command markdown instructs Claude to pick these up on every invocation — no flags needed after that.
+
+```markdown
+## TFVC Mirror
+
+- Mirror path: /c/temp/bgvtsw-tfvc-readonly
+- Mirror prefix: $/BGV Databases/RedGate/BGVTSWCustom
+```
+
+Once that's in place, `/tfvc-search find procs referencing ColumnX` will walk the local mirror instead of hitting ADO. No per-call flags, no re-explaining the mirror each session.
+
+If you only have a mirror for some subtrees, document just those — the skill falls back to REST when the requested scope isn't under the mirror prefix.
+
+**Manual override:** you can still pass `--mirror` and `--mirror-prefix` explicitly on the command line if you want to point at a different mirror for a one-off call. The two flags must be given together.
 
 ## Output
 

--- a/plugins/tfvc-search/README.md
+++ b/plugins/tfvc-search/README.md
@@ -1,0 +1,70 @@
+# tfvc-search
+
+Search and read Azure DevOps TFVC content (typically SQL schema scripts — stored procs, functions, views, tables) via the TFVC REST API. No workspace mapping, no cloning, no `tf.exe`.
+
+## Install
+
+```
+/plugin install tfvc-search@tzander-skills
+```
+
+## Prerequisites
+
+- **Azure CLI (`az`)** on `PATH` — the script picks up your existing credentials via `az account get-access-token`.
+- **`az login`** completed at least once. If not, the skill will tell you.
+- **Python 3** on `PATH` — stdlib only, no external dependencies.
+
+## Usage
+
+Invoke via `/tfvc-search` with a natural-language query, or run the script directly:
+
+```bash
+python3 path/to/tfvc-search.py grep \
+  --org <ORG> --project "<PROJECT>" \
+  --scope '$/Path/To/Scope' \
+  --pattern 'RegexHere' \
+  [--file-glob '*.sql'] \
+  [--mirror /local/path --mirror-prefix '$/Matching/Tfvc/Path']
+
+python3 path/to/tfvc-search.py read \
+  --org <ORG> --project "<PROJECT>" \
+  --path '$/Path/To/File.sql'
+
+python3 path/to/tfvc-search.py ls \
+  --org <ORG> --project "<PROJECT>" \
+  --scope '$/Path/To/Scope' [--recursive]
+```
+
+## Optional: local mirror
+
+If your team keeps a read-only local mirror of the TFVC subtree (e.g. `C:/temp/bgvtsw-tfvc-readonly/`), pass `--mirror` and `--mirror-prefix` together. When the mirror covers the full scope, the skill skips REST and walks the filesystem — orders of magnitude faster and works offline. On a per-file basis, `read` also prefers the mirror.
+
+Consider documenting your mirror path and org/project defaults in your repo's `CLAUDE.md` so the skill picks them up automatically.
+
+## Output
+
+- `grep` → `path:line:text` (grep-compatible)
+- `read` → raw file content to stdout
+- `ls` → one path per line; folders get a trailing `/`
+
+## Path-escaping note
+
+TFVC paths start with `$` and often contain spaces. Always single-quote them in Bash:
+
+```bash
+--scope '$/BGV Databases/RedGate/BGVTSWCustom'
+```
+
+Double quotes will make the shell try to expand `$/…` as a variable.
+
+## Scope (v1)
+
+Read-only: `grep`, `read`, `ls`. No check-ins, edits, branching, or changeset history. Live-DB inspection (current deployed state via `sqlcmd`) is explicitly out of scope — it's a separate concern with its own policy considerations.
+
+## Tests
+
+```bash
+python3 plugins/tfvc-search/scripts/test_tfvc-search.py
+```
+
+Tests mock both `az` and `urllib.request.urlopen` — no network required.

--- a/plugins/tfvc-search/README.md
+++ b/plugins/tfvc-search/README.md
@@ -19,18 +19,18 @@ Search and read Azure DevOps TFVC content (typically SQL schema scripts — stor
 Invoke via `/tfvc-search` with a natural-language query, or run the script directly:
 
 ```bash
-python3 path/to/tfvc-search.py grep \
+python path/to/tfvc-search.py grep \
   --org <ORG> --project "<PROJECT>" \
   --scope '$/Path/To/Scope' \
   --pattern 'RegexHere' \
   [--file-glob '*.sql'] \
   [--mirror /local/path --mirror-prefix '$/Matching/Tfvc/Path']
 
-python3 path/to/tfvc-search.py read \
+python path/to/tfvc-search.py read \
   --org <ORG> --project "<PROJECT>" \
   --path '$/Path/To/File.sql'
 
-python3 path/to/tfvc-search.py ls \
+python path/to/tfvc-search.py ls \
   --org <ORG> --project "<PROJECT>" \
   --scope '$/Path/To/Scope' [--recursive]
 ```
@@ -64,7 +64,7 @@ Read-only: `grep`, `read`, `ls`. No check-ins, edits, branching, or changeset hi
 ## Tests
 
 ```bash
-python3 plugins/tfvc-search/scripts/test_tfvc-search.py
+python plugins/tfvc-search/scripts/test_tfvc-search.py
 ```
 
 Tests mock both `az` and `urllib.request.urlopen` — no network required.

--- a/plugins/tfvc-search/commands/tfvc-search.md
+++ b/plugins/tfvc-search/commands/tfvc-search.md
@@ -54,7 +54,16 @@ TFVC paths start with `$` and often contain spaces — e.g. `$/BGV Databases/Red
 
 ## Local mirror (optional, much faster)
 
-If the user has a read-only local mirror of the TFVC subtree (e.g. `C:/temp/bgvtsw-tfvc-readonly/` mapped to `$/BGV Databases/RedGate/BGVTSWCustom`), pass `--mirror` and `--mirror-prefix`:
+**Before making any REST call, check the conversation's loaded CLAUDE.md context for a documented TFVC mirror** — both the project-level `CLAUDE.md` and the user-global `~/.claude/CLAUDE.md`. Users commonly maintain a read-only local mirror of their TFVC subtree and want the skill to use it automatically without having to pass flags on every invocation.
+
+Look for a section headed `## TFVC Mirror` (or similar) with two pieces of information:
+
+- A **mirror path** — a local directory containing a checked-out copy of some TFVC subtree (e.g. `C:/temp/bgvtsw-tfvc-readonly` or `/c/temp/bgvtsw-tfvc-readonly`).
+- A **mirror prefix** — the TFVC path that the mirror's root corresponds to (e.g. `$/BGV Databases/RedGate/BGVTSWCustom`).
+
+If both are present in CLAUDE.md, **always pass `--mirror` and `--mirror-prefix` on every invocation** — no need to ask the user or mention it. Project-level CLAUDE.md wins over the user-global one if they disagree. If only one of the two values is documented, treat the mirror as absent and fall back to REST.
+
+Full invocation with mirror:
 
 ```bash
 MSYS_NO_PATHCONV=1 python "$SCRIPT" grep \
@@ -67,7 +76,7 @@ MSYS_NO_PATHCONV=1 python "$SCRIPT" grep \
 
 When the mirror covers the full scope, the script skips REST entirely and walks the local filesystem — orders of magnitude faster and works offline. `read` also prefers the mirror on a per-file basis. The two flags must be given together or the script errors out.
 
-**Check the user's repo `CLAUDE.md` for a mirror path before making REST calls.** If a mirror is documented, use it unconditionally — it avoids network round-trips and respects any org policy against reaching the live DB or live TFVC during investigation.
+If no mirror is documented and the user asks for a large or recursive grep, mention once that adding a mirror block to `~/.claude/CLAUDE.md` will speed future runs — then proceed with REST. Do not pester on every call.
 
 ## Output format
 

--- a/plugins/tfvc-search/commands/tfvc-search.md
+++ b/plugins/tfvc-search/commands/tfvc-search.md
@@ -38,8 +38,10 @@ Locate the script and run the appropriate subcommand — Bash shell state does n
 
 ```bash
 SCRIPT=$(find ~/.claude -name tfvc-search.py -path "*/tfvc-search/*" -type f 2>/dev/null | head -1)
-python "$SCRIPT" <subcommand> --org <ORG> --project "<PROJECT>" ...
+MSYS_NO_PATHCONV=1 python "$SCRIPT" <subcommand> --org <ORG> --project "<PROJECT>" ...
 ```
+
+**Always prefix with `MSYS_NO_PATHCONV=1` on Windows/Git Bash.** Without it, Git Bash rewrites the TFVC `$/...` path into `$<drive>:<mount>/...` before Python receives it — the script detects this mangling and errors out clearly, but prevention is cheaper than recovery. The env var is harmless on non-MSYS shells.
 
 Org and project must come from the user's repo/project `CLAUDE.md` (often stored under `## SQL Database Reference` or similar), or from the user directly. Do not guess.
 
@@ -48,14 +50,14 @@ Org and project must come from the user's repo/project `CLAUDE.md` (often stored
 TFVC paths start with `$` and often contain spaces — e.g. `$/BGV Databases/RedGate/BGVTSWCustom`. In Bash:
 
 - **Always single-quote the path:** `'$/BGV Databases/RedGate/BGVTSWCustom'`. Double-quoting will make the shell try to expand `$/...` as a variable.
-- On Git Bash / MSYS, if a path arg starts with `/` and is being passed to a Windows-side binary, MSYS may rewrite it. This skill's Python wrapper avoids that layer, but if you see path mangling, prefix the whole command with `MSYS_NO_PATHCONV=1`.
+- **On Git Bash / MSYS, always prefix with `MSYS_NO_PATHCONV=1`** (as shown in the invocation block above). MSYS silently rewrites args that start with `/` into Windows-style paths *before* Python receives them — so `'$/BGV Databases/...'` becomes `'$C:/Program Files/Git/BGV Databases/...'` and the ADO API rejects it with `InvalidPathException`. The env var is harmless on non-MSYS shells, so it's safe to always include.
 
 ## Local mirror (optional, much faster)
 
 If the user has a read-only local mirror of the TFVC subtree (e.g. `C:/temp/bgvtsw-tfvc-readonly/` mapped to `$/BGV Databases/RedGate/BGVTSWCustom`), pass `--mirror` and `--mirror-prefix`:
 
 ```bash
-python "$SCRIPT" grep \
+MSYS_NO_PATHCONV=1 python "$SCRIPT" grep \
   --org bgvone --project "BGV Databases" \
   --scope '$/BGV Databases/RedGate/BGVTSWCustom' \
   --pattern 'ColumnX' --file-glob '*.sql' \

--- a/plugins/tfvc-search/commands/tfvc-search.md
+++ b/plugins/tfvc-search/commands/tfvc-search.md
@@ -1,0 +1,80 @@
+---
+name: tfvc-search
+description: Search and read Azure DevOps TFVC content (SQL schema scripts, etc.) via REST without a local workspace
+allowed-tools: Bash
+user-input: required
+argument-hint: "[grep|read|ls] <args>  OR  <natural-language query>"
+model: sonnet
+---
+
+You help the user investigate Azure DevOps TFVC content without cloning or mapping a workspace. TFVC is typically used in this context to store SQL schema scripts (stored procs, functions, tables, views) that sit outside a git repo — so the common task is grepping across `.sql` files by name or content.
+
+## Operations
+
+The skill wraps `tfvc-search.py`, which exposes three subcommands:
+
+- **`grep`** — recursive regex search under a scope path. Supports `--file-glob` to narrow by filename.
+- **`read`** — fetch the full content of a single TFVC item.
+- **`ls`** — list files/folders under a path (default one level; `--recursive` for full).
+
+## Interpreting user intent
+
+Translate natural-language asks into the right subcommand:
+
+| User asks… | Run |
+|---|---|
+| *"find procs that reference ColumnX under `$/Foo/Bar`"* | `grep --scope '$/Foo/Bar' --pattern 'ColumnX' --file-glob '*.sql'` |
+| *"show me the body of `$/Foo/Bar/dbo.MyProc.sql`"* | `read --path '$/Foo/Bar/dbo.MyProc.sql'` |
+| *"what's under `$/Foo/Bar`"* | `ls --scope '$/Foo/Bar'` (or add `--recursive` if they ask for the full tree) |
+| *"is there a function called `stc.GetSalesAgents` under `$/BGV/RedGate/Custom`"* | `ls --scope '$/BGV/RedGate/Custom/Functions' --recursive` first, then `read --path '...'` on the hit |
+
+When the user names a SQL object by schema-qualified name (e.g. `stc.GetSalesAgents`), the RedGate SQL Source Control layout is `$/<Project>/RedGate/<Db>/{Stored Procedures,Functions,Views,Tables,Synonyms,Security/Schemas}/<schema>.<Name>.sql`. Narrow the `--scope` by kind when you can (`Functions/` vs `Stored Procedures/`) — much faster than recursive grep over the whole DB.
+
+## Invocation
+
+**Prerequisite:** `az login` must be done (the script uses `az account get-access-token` for ADO auth). If the script errors with "run 'az login'", tell the user to authenticate and retry.
+
+Locate the script and run the appropriate subcommand — Bash shell state does not persist between tool calls, so resolve the path in each step:
+
+```bash
+SCRIPT=$(find ~/.claude -name tfvc-search.py -path "*/tfvc-search/*" -type f 2>/dev/null | head -1)
+python3 "$SCRIPT" <subcommand> --org <ORG> --project "<PROJECT>" ...
+```
+
+Org and project must come from the user's repo/project `CLAUDE.md` (often stored under `## SQL Database Reference` or similar), or from the user directly. Do not guess.
+
+## Path-escaping footgun
+
+TFVC paths start with `$` and often contain spaces — e.g. `$/BGV Databases/RedGate/BGVTSWCustom`. In Bash:
+
+- **Always single-quote the path:** `'$/BGV Databases/RedGate/BGVTSWCustom'`. Double-quoting will make the shell try to expand `$/...` as a variable.
+- On Git Bash / MSYS, if a path arg starts with `/` and is being passed to a Windows-side binary, MSYS may rewrite it. This skill's Python wrapper avoids that layer, but if you see path mangling, prefix the whole command with `MSYS_NO_PATHCONV=1`.
+
+## Local mirror (optional, much faster)
+
+If the user has a read-only local mirror of the TFVC subtree (e.g. `C:/temp/bgvtsw-tfvc-readonly/` mapped to `$/BGV Databases/RedGate/BGVTSWCustom`), pass `--mirror` and `--mirror-prefix`:
+
+```bash
+python3 "$SCRIPT" grep \
+  --org bgvone --project "BGV Databases" \
+  --scope '$/BGV Databases/RedGate/BGVTSWCustom' \
+  --pattern 'ColumnX' --file-glob '*.sql' \
+  --mirror '/c/temp/bgvtsw-tfvc-readonly' \
+  --mirror-prefix '$/BGV Databases/RedGate/BGVTSWCustom'
+```
+
+When the mirror covers the full scope, the script skips REST entirely and walks the local filesystem — orders of magnitude faster and works offline. `read` also prefers the mirror on a per-file basis. The two flags must be given together or the script errors out.
+
+**Check the user's repo `CLAUDE.md` for a mirror path before making REST calls.** If a mirror is documented, use it unconditionally — it avoids network round-trips and respects any org policy against reaching the live DB or live TFVC during investigation.
+
+## Output format
+
+- `grep` prints `path:line:text` (grep-compatible) — one match per line.
+- `read` writes raw file content to stdout.
+- `ls` prints one path per line; folders get a trailing `/`.
+
+On large scopes, `grep` fetches content per-file over REST, which is slow. Narrow with `--scope` (to a subfolder) and `--file-glob` (to `*.sql` or the specific kind directory) before grepping.
+
+## Out of scope
+
+This skill is read-only: no check-ins, edits, branching, or changeset history in v1. If the user wants the current *deployed* state of a SQL object (rather than source-controlled), that requires a separate live-DB path — not provided here — and may be against policy in some projects. Do not reach for `sqlcmd` without explicit user consent.

--- a/plugins/tfvc-search/commands/tfvc-search.md
+++ b/plugins/tfvc-search/commands/tfvc-search.md
@@ -38,7 +38,7 @@ Locate the script and run the appropriate subcommand — Bash shell state does n
 
 ```bash
 SCRIPT=$(find ~/.claude -name tfvc-search.py -path "*/tfvc-search/*" -type f 2>/dev/null | head -1)
-python3 "$SCRIPT" <subcommand> --org <ORG> --project "<PROJECT>" ...
+python "$SCRIPT" <subcommand> --org <ORG> --project "<PROJECT>" ...
 ```
 
 Org and project must come from the user's repo/project `CLAUDE.md` (often stored under `## SQL Database Reference` or similar), or from the user directly. Do not guess.
@@ -55,7 +55,7 @@ TFVC paths start with `$` and often contain spaces — e.g. `$/BGV Databases/Red
 If the user has a read-only local mirror of the TFVC subtree (e.g. `C:/temp/bgvtsw-tfvc-readonly/` mapped to `$/BGV Databases/RedGate/BGVTSWCustom`), pass `--mirror` and `--mirror-prefix`:
 
 ```bash
-python3 "$SCRIPT" grep \
+python "$SCRIPT" grep \
   --org bgvone --project "BGV Databases" \
   --scope '$/BGV Databases/RedGate/BGVTSWCustom' \
   --pattern 'ColumnX' --file-glob '*.sql' \

--- a/plugins/tfvc-search/commands/tfvc-search.md
+++ b/plugins/tfvc-search/commands/tfvc-search.md
@@ -38,6 +38,7 @@ Locate the script and run the appropriate subcommand — Bash shell state does n
 
 ```bash
 SCRIPT=$(find ~/.claude -name tfvc-search.py -path "*/tfvc-search/*" -type f 2>/dev/null | head -1)
+[ -n "$SCRIPT" ] || { echo "tfvc-search.py not found under ~/.claude — re-install: /plugin install tfvc-search@tzander-skills" >&2; exit 1; }
 MSYS_NO_PATHCONV=1 python "$SCRIPT" <subcommand> --org <ORG> --project "<PROJECT>" ...
 ```
 

--- a/plugins/tfvc-search/commands/tfvc-search.md
+++ b/plugins/tfvc-search/commands/tfvc-search.md
@@ -76,7 +76,18 @@ MSYS_NO_PATHCONV=1 python "$SCRIPT" grep \
 
 When the mirror covers the full scope, the script skips REST entirely and walks the local filesystem — orders of magnitude faster and works offline. `read` also prefers the mirror on a per-file basis. The two flags must be given together or the script errors out.
 
-If no mirror is documented and the user asks for a large or recursive grep, mention once that adding a mirror block to `~/.claude/CLAUDE.md` will speed future runs — then proceed with REST. Do not pester on every call.
+**First REST call in a session, if no mirror is documented:** emit this one-time tip to the user *before* the call:
+
+> Running this search via REST. If you have (or can create) a read-only local mirror of the TFVC subtree, add a block like this to your `~/.claude/CLAUDE.md` once and I'll use it automatically on every future call — much faster, works offline:
+>
+> ```markdown
+> ## TFVC Mirror
+>
+> - Mirror path: <local directory, e.g. /c/temp/bgvtsw-tfvc-readonly>
+> - Mirror prefix: <TFVC path that directory mirrors, e.g. $/BGV Databases/RedGate/BGVTSWCustom>
+> ```
+
+Then proceed with the REST call. **Do not re-emit this tip on subsequent calls in the same session** — once is enough, the user has the template. If the user acknowledges they don't have a mirror / don't want one, drop the tip entirely.
 
 ## Output format
 

--- a/plugins/tfvc-search/scripts/test_tfvc-search.py
+++ b/plugins/tfvc-search/scripts/test_tfvc-search.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Smoke tests for tfvc-search.py — run via `python3 test_tfvc-search.py`.
+
+Mocks `az` (token fetch) and `urllib.request.urlopen` (REST calls). No network required.
+"""
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+def _load_module():
+    here = Path(__file__).resolve().parent
+    spec = importlib.util.spec_from_file_location("tfvc_search", here / "tfvc-search.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+tfvc = _load_module()
+
+
+def _fake_token_subprocess():
+    result = mock.Mock()
+    result.stdout = "FAKE_TOKEN\n"
+    result.returncode = 0
+    return result
+
+
+def _http_response(body_bytes):
+    resp = mock.MagicMock()
+    resp.__enter__.return_value = resp
+    resp.read.return_value = body_bytes
+    return resp
+
+
+class CliValidationTests(unittest.TestCase):
+    def test_no_subcommand_errors(self):
+        with self.assertRaises(SystemExit):
+            tfvc.main([])
+
+    def test_grep_requires_pattern(self):
+        with self.assertRaises(SystemExit):
+            tfvc.main(["grep", "--org", "o", "--project", "p", "--scope", "$/S"])
+
+    def test_mirror_without_prefix_errors(self):
+        with self.assertRaises(SystemExit):
+            tfvc.main([
+                "read", "--org", "o", "--project", "p",
+                "--path", "$/S/F.sql", "--mirror", "/tmp/m",
+            ])
+
+    def test_mirror_prefix_without_mirror_errors(self):
+        with self.assertRaises(SystemExit):
+            tfvc.main([
+                "read", "--org", "o", "--project", "p",
+                "--path", "$/S/F.sql", "--mirror-prefix", "$/S",
+            ])
+
+    def test_org_url_is_normalized(self):
+        parser = tfvc.build_parser()
+        args = parser.parse_args([
+            "ls", "--org", "https://dev.azure.com/myorg/",
+            "--project", "p", "--scope", "$/S",
+        ])
+        # main() does the normalization, so simulate that step
+        if args.org.startswith(("http://", "https://")):
+            args.org = args.org.rstrip("/").rsplit("/", 1)[-1]
+        self.assertEqual(args.org, "myorg")
+
+
+class DecodeContentTests(unittest.TestCase):
+    def test_utf8(self):
+        self.assertEqual(tfvc._decode_content(b"hello"), "hello")
+
+    def test_utf16_le_bom(self):
+        self.assertEqual(tfvc._decode_content(b"\xff\xfeh\x00i\x00"), "hi")
+
+    def test_utf16_be_bom(self):
+        self.assertEqual(tfvc._decode_content(b"\xfe\xff\x00h\x00i"), "hi")
+
+    def test_invalid_utf8_falls_back_to_replace(self):
+        out = tfvc._decode_content(b"abc\xff\xfe\x00xyz")  # not a valid BOM at start, bad utf-8
+        # Doesn't crash; contains the ascii portions
+        self.assertIn("abc", out)
+
+
+class MirrorLookupTests(unittest.TestCase):
+    def test_miss_when_mirror_not_set(self):
+        self.assertIsNone(tfvc.mirror_lookup(None, None, "$/S/F.sql"))
+
+    def test_miss_when_path_outside_prefix(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertIsNone(tfvc.mirror_lookup(d, "$/OTHER", "$/S/F.sql"))
+
+    def test_hit_when_file_exists(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "sub" / "F.sql"
+            p.parent.mkdir(parents=True)
+            p.write_text("contents")
+            got = tfvc.mirror_lookup(d, "$/S", "$/S/sub/F.sql")
+            self.assertEqual(got, p)
+
+    def test_miss_when_file_absent(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertIsNone(tfvc.mirror_lookup(d, "$/S", "$/S/absent.sql"))
+
+
+class CmdLsTests(unittest.TestCase):
+    def setUp(self):
+        tfvc.get_access_token.cache_clear()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_non_recursive_uses_onelevel(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(json.dumps({
+            "value": [
+                {"path": "$/S", "isFolder": True},
+                {"path": "$/S/A.sql", "isFolder": False},
+                {"path": "$/S/sub", "isFolder": True},
+            ],
+        }).encode())
+
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "$/S"])
+
+        called_url = urlopen.call_args[0][0].full_url
+        self.assertIn("recursionLevel=OneLevel", called_url)
+        # Scope itself is filtered out; subfolder gets trailing slash
+        lines = out.getvalue().strip().splitlines()
+        self.assertEqual(lines, ["$/S/A.sql", "$/S/sub/"])
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_recursive_uses_full(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(b'{"value":[]}')
+        tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "$/S", "--recursive"])
+        self.assertIn("recursionLevel=Full", urlopen.call_args[0][0].full_url)
+
+
+class CmdReadTests(unittest.TestCase):
+    def setUp(self):
+        tfvc.get_access_token.cache_clear()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_rest_path(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(b"SELECT 1;\n")
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main(["read", "--org", "o", "--project", "p", "--path", "$/S/F.sql"])
+        self.assertEqual(out.getvalue(), "SELECT 1;\n")
+        # Accept header is text/plain for content
+        call_req = urlopen.call_args[0][0]
+        self.assertEqual(call_req.headers.get("Accept"), "text/plain")
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_mirror_hit_skips_rest(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "F.sql"
+            # write_bytes avoids Windows text-mode \r\n translation in the fixture
+            p.write_bytes(b"-- from mirror\n")
+            with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+                tfvc.main([
+                    "read", "--org", "o", "--project", "p",
+                    "--path", "$/S/F.sql",
+                    "--mirror", d, "--mirror-prefix", "$/S",
+                ])
+            self.assertEqual(out.getvalue(), "-- from mirror\n")
+            urlopen.assert_not_called()
+
+
+class CmdGrepTests(unittest.TestCase):
+    def setUp(self):
+        tfvc.get_access_token.cache_clear()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_rest_emits_path_line_text(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        list_resp = _http_response(json.dumps({
+            "value": [
+                {"path": "$/S/a.sql", "isFolder": False},
+                {"path": "$/S/b.txt", "isFolder": False},
+            ],
+        }).encode())
+        a_body = _http_response(b"line one\nhas ColumnX here\nline three\n")
+        b_body = _http_response(b"ColumnX also in b\n")
+        urlopen.side_effect = [list_resp, a_body, b_body]
+
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main([
+                "grep", "--org", "o", "--project", "p",
+                "--scope", "$/S", "--pattern", "ColumnX",
+            ])
+
+        lines = out.getvalue().strip().splitlines()
+        self.assertEqual(lines, [
+            "$/S/a.sql:2:has ColumnX here",
+            "$/S/b.txt:1:ColumnX also in b",
+        ])
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_file_glob_narrows(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        list_resp = _http_response(json.dumps({
+            "value": [
+                {"path": "$/S/a.sql", "isFolder": False},
+                {"path": "$/S/b.txt", "isFolder": False},
+            ],
+        }).encode())
+        a_body = _http_response(b"ColumnX in a\n")
+        urlopen.side_effect = [list_resp, a_body]  # b.txt must be filtered before fetch
+
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main([
+                "grep", "--org", "o", "--project", "p",
+                "--scope", "$/S", "--pattern", "ColumnX",
+                "--file-glob", "*.sql",
+            ])
+
+        self.assertEqual(out.getvalue().strip(), "$/S/a.sql:1:ColumnX in a")
+        # Only the list call + a.sql fetch — b.txt should not have been requested
+        self.assertEqual(urlopen.call_count, 2)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_mirror_covering_scope_skips_rest(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "a.sql").write_text("hit ColumnX\nother\n")
+            (Path(d) / "nested").mkdir()
+            (Path(d) / "nested" / "b.sql").write_text("also ColumnX\n")
+
+            with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+                tfvc.main([
+                    "grep", "--org", "o", "--project", "p",
+                    "--scope", "$/S", "--pattern", "ColumnX",
+                    "--mirror", d, "--mirror-prefix", "$/S",
+                ])
+
+            output_lines = sorted(out.getvalue().strip().splitlines())
+            self.assertEqual(output_lines, [
+                "$/S/a.sql:1:hit ColumnX",
+                "$/S/nested/b.sql:1:also ColumnX",
+            ])
+            urlopen.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/tfvc-search/scripts/test_tfvc-search.py
+++ b/plugins/tfvc-search/scripts/test_tfvc-search.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke tests for tfvc-search.py — run via `python3 test_tfvc-search.py`.
+"""Smoke tests for tfvc-search.py — run via `python test_tfvc-search.py`.
 
 Mocks `az` (token fetch) and `urllib.request.urlopen` (REST calls). No network required.
 """
@@ -7,16 +7,17 @@ Mocks `az` (token fetch) and `urllib.request.urlopen` (REST calls). No network r
 import importlib.util
 import io
 import json
-import os
-import sys
+import subprocess
 import tempfile
-import textwrap
 import unittest
+import urllib.error
+import urllib.parse
 from pathlib import Path
 from unittest import mock
 
 
 def _load_module():
+    # Filename has a hyphen, so import via spec rather than `import tfvc_search`.
     here = Path(__file__).resolve().parent
     spec = importlib.util.spec_from_file_location("tfvc_search", here / "tfvc-search.py")
     mod = importlib.util.module_from_spec(spec)
@@ -39,6 +40,16 @@ def _http_response(body_bytes):
     resp.__enter__.return_value = resp
     resp.read.return_value = body_bytes
     return resp
+
+
+def _http_error(code=500, reason="Server Error", body=b""):
+    return urllib.error.HTTPError(
+        url="https://example.com",
+        code=code,
+        msg=reason,
+        hdrs={},
+        fp=io.BytesIO(body),
+    )
 
 
 class CliValidationTests(unittest.TestCase):
@@ -64,16 +75,22 @@ class CliValidationTests(unittest.TestCase):
                 "--path", "$/S/F.sql", "--mirror-prefix", "$/S",
             ])
 
-    def test_org_url_is_normalized(self):
-        parser = tfvc.build_parser()
-        args = parser.parse_args([
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_org_url_is_normalized_at_runtime(self, urlopen, run):
+        # Functional check: pass a full dev.azure.com URL and verify the request URL
+        # built by main() uses only the org name, not the full URL.
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(b'{"value":[]}')
+        tfvc.main([
             "ls", "--org", "https://dev.azure.com/myorg/",
             "--project", "p", "--scope", "$/S",
         ])
-        # main() does the normalization, so simulate that step
-        if args.org.startswith(("http://", "https://")):
-            args.org = args.org.rstrip("/").rsplit("/", 1)[-1]
-        self.assertEqual(args.org, "myorg")
+        called_url = urlopen.call_args[0][0].full_url
+        self.assertTrue(
+            called_url.startswith("https://dev.azure.com/myorg/p/_apis/tfvc/items?"),
+            f"Expected normalized org in URL, got: {called_url}",
+        )
 
 
 class DecodeContentTests(unittest.TestCase):
@@ -88,7 +105,6 @@ class DecodeContentTests(unittest.TestCase):
 
     def test_invalid_utf8_falls_back_to_replace(self):
         out = tfvc._decode_content(b"abc\xff\xfe\x00xyz")  # not a valid BOM at start, bad utf-8
-        # Doesn't crash; contains the ascii portions
         self.assertIn("abc", out)
 
 
@@ -113,6 +129,27 @@ class MirrorLookupTests(unittest.TestCase):
             self.assertIsNone(tfvc.mirror_lookup(d, "$/S", "$/S/absent.sql"))
 
 
+class AuthTests(unittest.TestCase):
+    def setUp(self):
+        tfvc.get_access_token.cache_clear()
+
+    @mock.patch("subprocess.run", side_effect=FileNotFoundError())
+    def test_missing_az_cli_exits_with_hint(self, _run):
+        # Any REST call triggers token fetch, which should exit clearly.
+        with self.assertRaises(SystemExit) as cm:
+            tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "$/S"])
+        self.assertIn("'az' CLI not found", str(cm.exception))
+
+    @mock.patch("subprocess.run")
+    def test_az_login_required_exits_with_hint(self, run):
+        run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd=["az"], stderr="Please run 'az login' to setup account.\n",
+        )
+        with self.assertRaises(SystemExit) as cm:
+            tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "$/S"])
+        self.assertIn("az login", str(cm.exception))
+
+
 class CmdLsTests(unittest.TestCase):
     def setUp(self):
         tfvc.get_access_token.cache_clear()
@@ -134,7 +171,6 @@ class CmdLsTests(unittest.TestCase):
 
         called_url = urlopen.call_args[0][0].full_url
         self.assertIn("recursionLevel=OneLevel", called_url)
-        # Scope itself is filtered out; subfolder gets trailing slash
         lines = out.getvalue().strip().splitlines()
         self.assertEqual(lines, ["$/S/A.sql", "$/S/sub/"])
 
@@ -145,6 +181,37 @@ class CmdLsTests(unittest.TestCase):
         urlopen.return_value = _http_response(b'{"value":[]}')
         tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "$/S", "--recursive"])
         self.assertIn("recursionLevel=Full", urlopen.call_args[0][0].full_url)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_scope_with_trailing_slash_is_filtered(self, urlopen, run):
+        # ADO sometimes returns the scope folder with a trailing slash; make sure
+        # the filter still skips it rather than emitting a spurious scope entry.
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(json.dumps({
+            "value": [
+                {"path": "$/S/", "isFolder": True},
+                {"path": "$/S/A.sql", "isFolder": False},
+            ],
+        }).encode())
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "$/S"])
+        self.assertEqual(out.getvalue().strip().splitlines(), ["$/S/A.sql"])
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_scope_filter_is_case_insensitive(self, urlopen, run):
+        # TFVC is case-insensitive; ADO's response may differ in casing from the caller's scope.
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(json.dumps({
+            "value": [
+                {"path": "$/FOO", "isFolder": True},
+                {"path": "$/FOO/A.sql", "isFolder": False},
+            ],
+        }).encode())
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "$/foo"])
+        self.assertEqual(out.getvalue().strip().splitlines(), ["$/FOO/A.sql"])
 
 
 class CmdReadTests(unittest.TestCase):
@@ -159,18 +226,14 @@ class CmdReadTests(unittest.TestCase):
         with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
             tfvc.main(["read", "--org", "o", "--project", "p", "--path", "$/S/F.sql"])
         self.assertEqual(out.getvalue(), "SELECT 1;\n")
-        # Accept header is text/plain for content
-        call_req = urlopen.call_args[0][0]
-        self.assertEqual(call_req.headers.get("Accept"), "text/plain")
+        self.assertEqual(urlopen.call_args[0][0].headers.get("Accept"), "text/plain")
 
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
     def test_mirror_hit_skips_rest(self, urlopen, run):
         run.return_value = _fake_token_subprocess()
         with tempfile.TemporaryDirectory() as d:
-            p = Path(d) / "F.sql"
-            # write_bytes avoids Windows text-mode \r\n translation in the fixture
-            p.write_bytes(b"-- from mirror\n")
+            (Path(d) / "F.sql").write_bytes(b"-- from mirror\n")
             with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
                 tfvc.main([
                     "read", "--org", "o", "--project", "p",
@@ -179,6 +242,37 @@ class CmdReadTests(unittest.TestCase):
                 ])
             self.assertEqual(out.getvalue(), "-- from mirror\n")
             urlopen.assert_not_called()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_http_404_exits_fatally(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        urlopen.side_effect = _http_error(code=404, reason="Not Found", body=b'{"message":"not found"}')
+        with self.assertRaises(SystemExit) as cm:
+            tfvc.main(["read", "--org", "o", "--project", "p", "--path", "$/S/missing.sql"])
+        msg = str(cm.exception)
+        self.assertIn("404", msg)
+        self.assertIn("Not Found", msg)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_url_error_exits_with_network_hint(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        urlopen.side_effect = urllib.error.URLError("Connection timed out")
+        with self.assertRaises(SystemExit) as cm:
+            tfvc.main(["read", "--org", "o", "--project", "p", "--path", "$/S/F.sql"])
+        self.assertIn("failed to reach server", str(cm.exception))
+        self.assertIn("Connection timed out", str(cm.exception))
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_project_with_spaces_is_url_encoded(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(b"")
+        tfvc.main(["read", "--org", "o", "--project", "BGV Databases", "--path", "$/S/F.sql"])
+        called_url = urlopen.call_args[0][0].full_url
+        self.assertIn("/BGV%20Databases/", called_url)
+        self.assertNotIn("BGV Databases", called_url)  # raw space should not appear
 
 
 class CmdGrepTests(unittest.TestCase):
@@ -205,8 +299,7 @@ class CmdGrepTests(unittest.TestCase):
                 "--scope", "$/S", "--pattern", "ColumnX",
             ])
 
-        lines = out.getvalue().strip().splitlines()
-        self.assertEqual(lines, [
+        self.assertEqual(out.getvalue().strip().splitlines(), [
             "$/S/a.sql:2:has ColumnX here",
             "$/S/b.txt:1:ColumnX also in b",
         ])
@@ -222,7 +315,7 @@ class CmdGrepTests(unittest.TestCase):
             ],
         }).encode())
         a_body = _http_response(b"ColumnX in a\n")
-        urlopen.side_effect = [list_resp, a_body]  # b.txt must be filtered before fetch
+        urlopen.side_effect = [list_resp, a_body]
 
         with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
             tfvc.main([
@@ -232,17 +325,16 @@ class CmdGrepTests(unittest.TestCase):
             ])
 
         self.assertEqual(out.getvalue().strip(), "$/S/a.sql:1:ColumnX in a")
-        # Only the list call + a.sql fetch — b.txt should not have been requested
-        self.assertEqual(urlopen.call_count, 2)
+        self.assertEqual(urlopen.call_count, 2)  # list + a.sql; b.txt never fetched
 
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
     def test_mirror_covering_scope_skips_rest(self, urlopen, run):
         run.return_value = _fake_token_subprocess()
         with tempfile.TemporaryDirectory() as d:
-            (Path(d) / "a.sql").write_text("hit ColumnX\nother\n")
+            (Path(d) / "a.sql").write_bytes(b"hit ColumnX\nother\n")
             (Path(d) / "nested").mkdir()
-            (Path(d) / "nested" / "b.sql").write_text("also ColumnX\n")
+            (Path(d) / "nested" / "b.sql").write_bytes(b"also ColumnX\n")
 
             with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
                 tfvc.main([
@@ -251,12 +343,94 @@ class CmdGrepTests(unittest.TestCase):
                     "--mirror", d, "--mirror-prefix", "$/S",
                 ])
 
-            output_lines = sorted(out.getvalue().strip().splitlines())
-            self.assertEqual(output_lines, [
+            self.assertEqual(sorted(out.getvalue().strip().splitlines()), [
                 "$/S/a.sql:1:hit ColumnX",
                 "$/S/nested/b.sql:1:also ColumnX",
             ])
             urlopen.assert_not_called()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_invalid_regex_exits_with_friendly_error(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        # urlopen shouldn't be called because the regex fails to compile first
+        with self.assertRaises(SystemExit) as cm:
+            tfvc.main([
+                "grep", "--org", "o", "--project", "p",
+                "--scope", "$/S", "--pattern", "(unclosed",
+            ])
+        self.assertIn("invalid regex", str(cm.exception))
+        urlopen.assert_not_called()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_empty_scope_produces_no_output(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(b'{"value":[]}')
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main([
+                "grep", "--org", "o", "--project", "p",
+                "--scope", "$/S", "--pattern", "anything",
+            ])
+        self.assertEqual(out.getvalue(), "")
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_per_file_http_error_is_logged_and_skipped(self, urlopen, run):
+        # File a.sql 403s (policy/ACL), b.sql succeeds.
+        # The whole grep must NOT abort — b.sql should still be searched.
+        run.return_value = _fake_token_subprocess()
+        list_resp = _http_response(json.dumps({
+            "value": [
+                {"path": "$/S/a.sql", "isFolder": False},
+                {"path": "$/S/b.sql", "isFolder": False},
+            ],
+        }).encode())
+        a_error = _http_error(code=403, reason="Forbidden", body=b'{"message":"forbidden"}')
+        b_body = _http_response(b"ColumnX is here\n")
+        urlopen.side_effect = [list_resp, a_error, b_body]
+
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out, \
+             mock.patch("sys.stderr", new_callable=io.StringIO) as err:
+            tfvc.main([
+                "grep", "--org", "o", "--project", "p",
+                "--scope", "$/S", "--pattern", "ColumnX",
+            ])
+
+        # b.sql match is printed; a.sql failure is in stderr but didn't abort.
+        self.assertEqual(out.getvalue().strip(), "$/S/b.sql:1:ColumnX is here")
+        self.assertIn("403", err.getvalue())
+        self.assertIn("Forbidden", err.getvalue())
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_list_call_failure_is_fatal(self, urlopen, run):
+        # If the enumeration itself fails, there's nothing to grep — abort.
+        run.return_value = _fake_token_subprocess()
+        urlopen.side_effect = _http_error(code=401, reason="Unauthorized", body=b"")
+        with self.assertRaises(SystemExit):
+            tfvc.main([
+                "grep", "--org", "o", "--project", "p",
+                "--scope", "$/S", "--pattern", "anything",
+            ])
+
+
+class TimeoutTests(unittest.TestCase):
+    def setUp(self):
+        tfvc.get_access_token.cache_clear()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_urlopen_is_called_with_timeout(self, urlopen, run):
+        # Belt-and-suspenders: ensure we never call urlopen without a timeout,
+        # or the script can hang indefinitely on network hiccups.
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(b'{"value":[]}')
+        tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "$/S"])
+        _, kwargs = urlopen.call_args
+        self.assertIn("timeout", kwargs)
+        self.assertIsNotNone(kwargs["timeout"])
+        self.assertGreater(kwargs["timeout"], 0)
 
 
 if __name__ == "__main__":

--- a/plugins/tfvc-search/scripts/test_tfvc-search.py
+++ b/plugins/tfvc-search/scripts/test_tfvc-search.py
@@ -75,6 +75,24 @@ class CliValidationTests(unittest.TestCase):
                 "--path", "$/S/F.sql", "--mirror-prefix", "$/S",
             ])
 
+    def test_msys_mangled_scope_is_rejected_with_fix_hint(self):
+        # MSYS/Git-Bash rewrites '$/Foo' into '$C:/Program Files/Git/Foo' before Python
+        # sees the arg. Detect that shape and point the user at MSYS_NO_PATHCONV=1.
+        with self.assertRaises(SystemExit) as cm:
+            tfvc.main([
+                "ls", "--org", "o", "--project", "p",
+                "--scope", "$C:/Program Files/Git/Foo/Bar",
+            ])
+        self.assertIn("MSYS_NO_PATHCONV=1", str(cm.exception))
+
+    def test_msys_mangled_path_is_rejected_with_fix_hint(self):
+        with self.assertRaises(SystemExit) as cm:
+            tfvc.main([
+                "read", "--org", "o", "--project", "p",
+                "--path", "$C:/Program Files/Git/Foo/F.sql",
+            ])
+        self.assertIn("MSYS_NO_PATHCONV=1", str(cm.exception))
+
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
     def test_org_url_is_normalized_at_runtime(self, urlopen, run):
@@ -133,9 +151,10 @@ class AuthTests(unittest.TestCase):
     def setUp(self):
         tfvc.get_access_token.cache_clear()
 
-    @mock.patch("subprocess.run", side_effect=FileNotFoundError())
-    def test_missing_az_cli_exits_with_hint(self, _run):
-        # Any REST call triggers token fetch, which should exit clearly.
+    @mock.patch("shutil.which", return_value=None)
+    def test_missing_az_cli_exits_with_hint(self, _which):
+        # Any REST call triggers token fetch; shutil.which returning None is the
+        # real-world "az not installed" signal on both POSIX and Windows.
         with self.assertRaises(SystemExit) as cm:
             tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "$/S"])
         self.assertIn("'az' CLI not found", str(cm.exception))

--- a/plugins/tfvc-search/scripts/test_tfvc-search.py
+++ b/plugins/tfvc-search/scripts/test_tfvc-search.py
@@ -11,7 +11,6 @@ import subprocess
 import tempfile
 import unittest
 import urllib.error
-import urllib.parse
 from pathlib import Path
 from unittest import mock
 
@@ -53,67 +52,171 @@ def _http_error(code=500, reason="Server Error", body=b""):
 
 
 class CliValidationTests(unittest.TestCase):
+    # argparse writes validation errors to stderr and exits with code 2. Assertions
+    # check stderr content (not just "any SystemExit") so a regression where the
+    # exit happens for an unrelated reason (e.g., az-not-found) would fail the test.
+
     def test_no_subcommand_errors(self):
-        with self.assertRaises(SystemExit):
+        with mock.patch("sys.stderr", new_callable=io.StringIO) as err, self.assertRaises(SystemExit):
             tfvc.main([])
+        self.assertIn("required", err.getvalue().lower())
 
     def test_grep_requires_pattern(self):
-        with self.assertRaises(SystemExit):
+        with mock.patch("sys.stderr", new_callable=io.StringIO) as err, self.assertRaises(SystemExit):
             tfvc.main(["grep", "--org", "o", "--project", "p", "--scope", "$/S"])
+        self.assertIn("--pattern", err.getvalue())
 
     def test_mirror_without_prefix_errors(self):
-        with self.assertRaises(SystemExit):
+        with mock.patch("sys.stderr", new_callable=io.StringIO) as err, self.assertRaises(SystemExit):
             tfvc.main([
                 "read", "--org", "o", "--project", "p",
                 "--path", "$/S/F.sql", "--mirror", "/tmp/m",
             ])
+        self.assertIn("--mirror and --mirror-prefix", err.getvalue())
 
     def test_mirror_prefix_without_mirror_errors(self):
-        with self.assertRaises(SystemExit):
+        with mock.patch("sys.stderr", new_callable=io.StringIO) as err, self.assertRaises(SystemExit):
             tfvc.main([
                 "read", "--org", "o", "--project", "p",
                 "--path", "$/S/F.sql", "--mirror-prefix", "$/S",
             ])
+        self.assertIn("--mirror and --mirror-prefix", err.getvalue())
 
-    def test_msys_mangled_scope_is_rejected_with_fix_hint(self):
-        # MSYS/Git-Bash rewrites '$/Foo' into '$C:/Program Files/Git/Foo' before Python
-        # sees the arg. Detect that shape and point the user at MSYS_NO_PATHCONV=1.
+
+class MsysMangleTests(unittest.TestCase):
+    """_check_msys_mangle rejects both mangled shapes and runs before other validation."""
+
+    def test_dollar_preserved_form_is_rejected(self):
+        # Form 1: bash preserved '$', MSYS rewrote to '$C:/...'.
         with self.assertRaises(SystemExit) as cm:
-            tfvc.main([
-                "ls", "--org", "o", "--project", "p",
-                "--scope", "$C:/Program Files/Git/Foo/Bar",
-            ])
+            tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "$C:/Program Files/Git/Foo"])
         self.assertIn("MSYS_NO_PATHCONV=1", str(cm.exception))
 
-    def test_msys_mangled_path_is_rejected_with_fix_hint(self):
+    def test_dollar_stripped_form_is_rejected(self):
+        # Form 2: bash ate '$' as undefined variable (empty), leaving '/Foo',
+        # which MSYS then rewrote to 'C:/Program Files/Git/Foo' (no '$').
         with self.assertRaises(SystemExit) as cm:
-            tfvc.main([
-                "read", "--org", "o", "--project", "p",
-                "--path", "$C:/Program Files/Git/Foo/F.sql",
-            ])
+            tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "C:/Program Files/Git/Foo/Bar"])
         self.assertIn("MSYS_NO_PATHCONV=1", str(cm.exception))
 
-    @mock.patch("subprocess.run")
-    @mock.patch("urllib.request.urlopen")
-    def test_org_url_is_normalized_at_runtime(self, urlopen, run):
-        # Functional check: pass a full dev.azure.com URL and verify the request URL
-        # built by main() uses only the org name, not the full URL.
-        run.return_value = _fake_token_subprocess()
-        urlopen.return_value = _http_response(b'{"value":[]}')
-        tfvc.main([
-            "ls", "--org", "https://dev.azure.com/myorg/",
-            "--project", "p", "--scope", "$/S",
-        ])
-        called_url = urlopen.call_args[0][0].full_url
-        self.assertTrue(
-            called_url.startswith("https://dev.azure.com/myorg/p/_apis/tfvc/items?"),
-            f"Expected normalized org in URL, got: {called_url}",
+    def test_path_flag_is_checked(self):
+        with self.assertRaises(SystemExit) as cm:
+            tfvc.main(["read", "--org", "o", "--project", "p", "--path", "$C:/Program Files/Git/Foo/F.sql"])
+        self.assertIn("--path", str(cm.exception))
+
+    def test_mirror_prefix_flag_is_checked(self):
+        # --mirror-prefix is the third TFVC-path flag; make sure the check loop hits it too.
+        with self.assertRaises(SystemExit) as cm:
+            tfvc.main([
+                "ls", "--org", "o", "--project", "p", "--scope", "$/S",
+                "--mirror", "/tmp/m", "--mirror-prefix", "$C:/mangled",
+            ])
+        self.assertIn("--mirror-prefix", str(cm.exception))
+
+    def test_valid_tfvc_path_passes_through(self):
+        # Negative: a correctly-formed '$/Foo/Bar' must NOT trigger the check.
+        # We mock the backends so the call goes through to a successful ls.
+        with mock.patch("subprocess.run") as run, mock.patch("urllib.request.urlopen") as urlopen:
+            run.return_value = _fake_token_subprocess()
+            urlopen.return_value = _http_response(b'{"value":[]}')
+            tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "$/Foo/Bar"])
+            urlopen.assert_called_once()
+
+    def test_msys_check_runs_before_mirror_symmetry_check(self):
+        # If the user passes a mangled --mirror-prefix AND forgets --mirror, they should
+        # see the specific MSYS hint rather than the generic "must be given together" error.
+        with self.assertRaises(SystemExit) as cm:
+            tfvc.main([
+                "ls", "--org", "o", "--project", "p", "--scope", "$/S",
+                "--mirror-prefix", "$C:/mangled",
+            ])
+        # Expect MSYS message, not the symmetry message.
+        msg = str(cm.exception)
+        self.assertIn("MSYS_NO_PATHCONV=1", msg)
+        self.assertNotIn("must be given together", msg)
+
+
+class OrgNormalizationTests(unittest.TestCase):
+    """_normalize_org extracts the org from bare names, modern URLs, and legacy URLs."""
+
+    def test_bare_org_unchanged(self):
+        self.assertEqual(tfvc._normalize_org("myorg"), "myorg")
+
+    def test_modern_url_single_path(self):
+        self.assertEqual(tfvc._normalize_org("https://dev.azure.com/myorg"), "myorg")
+
+    def test_modern_url_trailing_slash(self):
+        self.assertEqual(tfvc._normalize_org("https://dev.azure.com/myorg/"), "myorg")
+
+    def test_modern_url_with_project_takes_first_segment(self):
+        # Critical regression: a user pasting a full browser URL would previously have
+        # been silently normalized to 'myproject'. Now it's correctly 'myorg'.
+        self.assertEqual(
+            tfvc._normalize_org("https://dev.azure.com/myorg/myproject"),
+            "myorg",
         )
+
+    def test_modern_url_with_deep_path(self):
+        self.assertEqual(
+            tfvc._normalize_org("https://dev.azure.com/myorg/myproject/_git/repo"),
+            "myorg",
+        )
+
+    def test_legacy_visualstudio_com_url(self):
+        self.assertEqual(
+            tfvc._normalize_org("https://myorg.visualstudio.com/"),
+            "myorg",
+        )
+
+    def test_legacy_visualstudio_com_url_with_path(self):
+        self.assertEqual(
+            tfvc._normalize_org("https://myorg.visualstudio.com/myproject/_apis/tfvc"),
+            "myorg",
+        )
+
+    def test_http_not_https(self):
+        self.assertEqual(tfvc._normalize_org("http://dev.azure.com/myorg/"), "myorg")
+
+    def test_unknown_url_shape_passes_through(self):
+        # If we don't recognize the host, leave as-is — the REST call will surface the mistake.
+        weird = "https://example.com/something"
+        self.assertEqual(tfvc._normalize_org(weird), weird)
+
+
+class PathIsUnderTests(unittest.TestCase):
+    def test_exact_equality(self):
+        self.assertTrue(tfvc._path_is_under("$/Foo/Bar", "$/Foo/Bar"))
+
+    def test_descendant(self):
+        self.assertTrue(tfvc._path_is_under("$/Foo/Bar/baz.sql", "$/Foo/Bar"))
+
+    def test_string_prefix_but_not_path_prefix_rejected(self):
+        # The critical bug fix: '$/Foobar' is a string prefix of '$/Foo' but NOT a path descendant.
+        self.assertFalse(tfvc._path_is_under("$/Foobar", "$/Foo"))
+        self.assertFalse(tfvc._path_is_under("$/Foobar/file.sql", "$/Foo"))
+
+    def test_case_insensitive_equality(self):
+        # TFVC is case-insensitive on Windows-backed ADO.
+        self.assertTrue(tfvc._path_is_under("$/FOO/BAR", "$/foo/bar"))
+
+    def test_case_insensitive_descendant(self):
+        self.assertTrue(tfvc._path_is_under("$/foo/BAR/File.sql", "$/FOO/bar"))
+
+    def test_trailing_slash_tolerance(self):
+        self.assertTrue(tfvc._path_is_under("$/Foo/", "$/Foo"))
+        self.assertTrue(tfvc._path_is_under("$/Foo", "$/Foo/"))
+
+    def test_unrelated_paths(self):
+        self.assertFalse(tfvc._path_is_under("$/Bar/baz.sql", "$/Foo"))
 
 
 class DecodeContentTests(unittest.TestCase):
     def test_utf8(self):
         self.assertEqual(tfvc._decode_content(b"hello"), "hello")
+
+    def test_utf8_bom_stripped(self):
+        # UTF-8 BOM must be stripped so line-anchored regex (e.g. `^CREATE`) matches line 1.
+        self.assertEqual(tfvc._decode_content(b"\xef\xbb\xbfCREATE PROC Foo\n"), "CREATE PROC Foo\n")
 
     def test_utf16_le_bom(self):
         self.assertEqual(tfvc._decode_content(b"\xff\xfeh\x00i\x00"), "hi")
@@ -122,8 +225,9 @@ class DecodeContentTests(unittest.TestCase):
         self.assertEqual(tfvc._decode_content(b"\xfe\xff\x00h\x00i"), "hi")
 
     def test_invalid_utf8_falls_back_to_replace(self):
-        out = tfvc._decode_content(b"abc\xff\xfe\x00xyz")  # not a valid BOM at start, bad utf-8
+        out = tfvc._decode_content(b"abc\x80\x81xyz")  # invalid UTF-8, no BOM at start
         self.assertIn("abc", out)
+        self.assertIn("xyz", out)
 
 
 class MirrorLookupTests(unittest.TestCase):
@@ -146,6 +250,25 @@ class MirrorLookupTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             self.assertIsNone(tfvc.mirror_lookup(d, "$/S", "$/S/absent.sql"))
 
+    def test_case_insensitive_match(self):
+        # Mirror prefix in one case, TFVC path in another — should still hit.
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "sub" / "F.sql"
+            p.parent.mkdir(parents=True)
+            p.write_text("contents")
+            got = tfvc.mirror_lookup(d, "$/s", "$/S/sub/F.sql")
+            self.assertEqual(got, p)
+
+    def test_string_prefix_boundary_mismatch_rejected(self):
+        # '$/Foobar' is a string prefix of '$/Foo' but should not resolve to the mirror.
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "bar" / "F.sql").parent.mkdir(parents=True)
+            (Path(d) / "bar" / "F.sql").write_text("x")
+            # If the old buggy logic stripped "$/Foo" from "$/Foobar/F.sql" it would
+            # look for `d/bar/F.sql` and (coincidentally) find it. Case-boundary check
+            # prevents that.
+            self.assertIsNone(tfvc.mirror_lookup(d, "$/Foo", "$/Foobar/F.sql"))
+
 
 class AuthTests(unittest.TestCase):
     def setUp(self):
@@ -153,8 +276,6 @@ class AuthTests(unittest.TestCase):
 
     @mock.patch("shutil.which", return_value=None)
     def test_missing_az_cli_exits_with_hint(self, _which):
-        # Any REST call triggers token fetch; shutil.which returning None is the
-        # real-world "az not installed" signal on both POSIX and Windows.
         with self.assertRaises(SystemExit) as cm:
             tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "$/S"])
         self.assertIn("'az' CLI not found", str(cm.exception))
@@ -190,8 +311,7 @@ class CmdLsTests(unittest.TestCase):
 
         called_url = urlopen.call_args[0][0].full_url
         self.assertIn("recursionLevel=OneLevel", called_url)
-        lines = out.getvalue().strip().splitlines()
-        self.assertEqual(lines, ["$/S/A.sql", "$/S/sub/"])
+        self.assertEqual(out.getvalue().strip().splitlines(), ["$/S/A.sql", "$/S/sub/"])
 
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
@@ -204,8 +324,6 @@ class CmdLsTests(unittest.TestCase):
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
     def test_scope_with_trailing_slash_is_filtered(self, urlopen, run):
-        # ADO sometimes returns the scope folder with a trailing slash; make sure
-        # the filter still skips it rather than emitting a spurious scope entry.
         run.return_value = _fake_token_subprocess()
         urlopen.return_value = _http_response(json.dumps({
             "value": [
@@ -220,7 +338,6 @@ class CmdLsTests(unittest.TestCase):
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
     def test_scope_filter_is_case_insensitive(self, urlopen, run):
-        # TFVC is case-insensitive; ADO's response may differ in casing from the caller's scope.
         run.return_value = _fake_token_subprocess()
         urlopen.return_value = _http_response(json.dumps({
             "value": [
@@ -264,6 +381,22 @@ class CmdReadTests(unittest.TestCase):
 
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
+    def test_mirror_miss_falls_back_to_rest(self, urlopen, run):
+        # With --mirror set but the file not on disk, fall through to REST.
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(b"from rest\n")
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+                tfvc.main([
+                    "read", "--org", "o", "--project", "p",
+                    "--path", "$/S/absent.sql",
+                    "--mirror", d, "--mirror-prefix", "$/S",
+                ])
+            self.assertEqual(out.getvalue(), "from rest\n")
+            urlopen.assert_called_once()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
     def test_http_404_exits_fatally(self, urlopen, run):
         run.return_value = _fake_token_subprocess()
         urlopen.side_effect = _http_error(code=404, reason="Not Found", body=b'{"message":"not found"}')
@@ -281,7 +414,6 @@ class CmdReadTests(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             tfvc.main(["read", "--org", "o", "--project", "p", "--path", "$/S/F.sql"])
         self.assertIn("failed to reach server", str(cm.exception))
-        self.assertIn("Connection timed out", str(cm.exception))
 
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
@@ -291,7 +423,7 @@ class CmdReadTests(unittest.TestCase):
         tfvc.main(["read", "--org", "o", "--project", "BGV Databases", "--path", "$/S/F.sql"])
         called_url = urlopen.call_args[0][0].full_url
         self.assertIn("/BGV%20Databases/", called_url)
-        self.assertNotIn("BGV Databases", called_url)  # raw space should not appear
+        self.assertNotIn("BGV Databases", called_url)
 
 
 class CmdGrepTests(unittest.TestCase):
@@ -344,7 +476,7 @@ class CmdGrepTests(unittest.TestCase):
             ])
 
         self.assertEqual(out.getvalue().strip(), "$/S/a.sql:1:ColumnX in a")
-        self.assertEqual(urlopen.call_count, 2)  # list + a.sql; b.txt never fetched
+        self.assertEqual(urlopen.call_count, 2)
 
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
@@ -370,9 +502,44 @@ class CmdGrepTests(unittest.TestCase):
 
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
+    def test_fast_path_rejects_non_boundary_prefix_match(self, urlopen, run):
+        # The regression: '$/Foobar' scope with '$/Foo' mirror prefix used to take the
+        # fast path (string-startswith true) and walk $MIRROR looking for nonexistent
+        # children, emitting nothing when it should have fallen through to REST.
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(b'{"value":[]}')  # REST enumeration returns empty
+        with tempfile.TemporaryDirectory() as d:
+            # Put a file under the mirror that would've matched if the bug existed.
+            (Path(d) / "F.sql").write_bytes(b"ColumnX\n")
+            tfvc.main([
+                "grep", "--org", "o", "--project", "p",
+                "--scope", "$/Foobar", "--pattern", "ColumnX",
+                "--mirror", d, "--mirror-prefix", "$/Foo",
+            ])
+            # If the fast path was (incorrectly) taken, urlopen would NOT be called.
+            # The fix causes the fast path to be rejected → REST call happens.
+            urlopen.assert_called_once()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_fast_path_case_insensitive(self, urlopen, run):
+        # Mirror prefix and scope differ in case — fast path should still engage.
+        run.return_value = _fake_token_subprocess()
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "a.sql").write_bytes(b"hit ColumnX\n")
+            with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+                tfvc.main([
+                    "grep", "--org", "o", "--project", "p",
+                    "--scope", "$/FOO", "--pattern", "ColumnX",
+                    "--mirror", d, "--mirror-prefix", "$/foo",
+                ])
+            self.assertIn("ColumnX", out.getvalue())
+            urlopen.assert_not_called()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
     def test_invalid_regex_exits_with_friendly_error(self, urlopen, run):
         run.return_value = _fake_token_subprocess()
-        # urlopen shouldn't be called because the regex fails to compile first
         with self.assertRaises(SystemExit) as cm:
             tfvc.main([
                 "grep", "--org", "o", "--project", "p",
@@ -396,8 +563,6 @@ class CmdGrepTests(unittest.TestCase):
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
     def test_per_file_http_error_is_logged_and_skipped(self, urlopen, run):
-        # File a.sql 403s (policy/ACL), b.sql succeeds.
-        # The whole grep must NOT abort — b.sql should still be searched.
         run.return_value = _fake_token_subprocess()
         list_resp = _http_response(json.dumps({
             "value": [
@@ -416,22 +581,59 @@ class CmdGrepTests(unittest.TestCase):
                 "--scope", "$/S", "--pattern", "ColumnX",
             ])
 
-        # b.sql match is printed; a.sql failure is in stderr but didn't abort.
         self.assertEqual(out.getvalue().strip(), "$/S/b.sql:1:ColumnX is here")
         self.assertIn("403", err.getvalue())
-        self.assertIn("Forbidden", err.getvalue())
 
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
     def test_list_call_failure_is_fatal(self, urlopen, run):
-        # If the enumeration itself fails, there's nothing to grep — abort.
         run.return_value = _fake_token_subprocess()
         urlopen.side_effect = _http_error(code=401, reason="Unauthorized", body=b"")
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(SystemExit) as cm:
             tfvc.main([
                 "grep", "--org", "o", "--project", "p",
                 "--scope", "$/S", "--pattern", "anything",
             ])
+        # Tighten: assert the error refers to the 401, not just any SystemExit.
+        self.assertIn("401", str(cm.exception))
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_grep_local_honors_file_glob(self, urlopen, run):
+        # Local fast-path + --file-glob: ensure the glob filter applies during os.walk.
+        run.return_value = _fake_token_subprocess()
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "a.sql").write_bytes(b"ColumnX here\n")
+            (Path(d) / "b.txt").write_bytes(b"ColumnX here too\n")
+            with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+                tfvc.main([
+                    "grep", "--org", "o", "--project", "p",
+                    "--scope", "$/S", "--pattern", "ColumnX",
+                    "--file-glob", "*.sql",
+                    "--mirror", d, "--mirror-prefix", "$/S",
+                ])
+            output = out.getvalue()
+            self.assertIn("a.sql", output)
+            self.assertNotIn("b.txt", output)
+            urlopen.assert_not_called()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_fast_path_stale_mirror_falls_back_with_warning(self, urlopen, run):
+        # Mirror prefix claims to cover scope but the target directory doesn't exist
+        # on disk — should emit a stderr warning AND fall through to REST.
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(b'{"value":[]}')
+        with tempfile.TemporaryDirectory() as d:
+            # Note: no `sub/` directory created.
+            with mock.patch("sys.stderr", new_callable=io.StringIO) as err:
+                tfvc.main([
+                    "grep", "--org", "o", "--project", "p",
+                    "--scope", "$/S/sub", "--pattern", "anything",
+                    "--mirror", d, "--mirror-prefix", "$/S",
+                ])
+            self.assertIn("Stale mirror", err.getvalue())
+            urlopen.assert_called_once()
 
 
 class TimeoutTests(unittest.TestCase):
@@ -440,16 +642,13 @@ class TimeoutTests(unittest.TestCase):
 
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
-    def test_urlopen_is_called_with_timeout(self, urlopen, run):
-        # Belt-and-suspenders: ensure we never call urlopen without a timeout,
-        # or the script can hang indefinitely on network hiccups.
+    def test_urlopen_is_called_with_expected_timeout(self, urlopen, run):
         run.return_value = _fake_token_subprocess()
         urlopen.return_value = _http_response(b'{"value":[]}')
         tfvc.main(["ls", "--org", "o", "--project", "p", "--scope", "$/S"])
         _, kwargs = urlopen.call_args
-        self.assertIn("timeout", kwargs)
-        self.assertIsNotNone(kwargs["timeout"])
-        self.assertGreater(kwargs["timeout"], 0)
+        # Tighten: assert the actual configured value, not just "> 0".
+        self.assertEqual(kwargs.get("timeout"), tfvc.DEFAULT_HTTP_TIMEOUT)
 
 
 if __name__ == "__main__":

--- a/plugins/tfvc-search/scripts/tfvc-search.py
+++ b/plugins/tfvc-search/scripts/tfvc-search.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 ADO_RESOURCE_ID = "499b84ac-1321-427f-aa17-267ca6975798"
 DEFAULT_API_VERSION = "7.1"
+DEFAULT_HTTP_TIMEOUT = 30
 
 
 @lru_cache(maxsize=1)
@@ -51,7 +52,17 @@ def get_access_token():
         )
 
 
-def _ado_request(url, accept):
+def _tfvc_items_base_url(org, project):
+    """Build the /_apis/tfvc/items base URL with org and project URL-encoded."""
+    return (
+        f"https://dev.azure.com/{urllib.parse.quote(org, safe='')}"
+        f"/{urllib.parse.quote(project, safe='')}/_apis/tfvc/items"
+    )
+
+
+def _ado_request(url, accept, *, fatal=True):
+    """GET a TFVC URL. Returns response bytes on success, or None on error when fatal=False.
+    When fatal=True (default), exits the process on any HTTP/network error."""
     req = urllib.request.Request(
         url,
         headers={
@@ -60,18 +71,22 @@ def _ado_request(url, accept):
         },
     )
     try:
-        with urllib.request.urlopen(req) as resp:
+        with urllib.request.urlopen(req, timeout=DEFAULT_HTTP_TIMEOUT) as resp:
             return resp.read()
     except urllib.error.HTTPError as e:
         body = e.read().decode("utf-8", errors="replace") if e.fp else ""
-        sys.exit(f"Error: TFVC API call failed: {e.code} {e.reason}\nURL: {url}\nResponse: {body}")
+        msg = f"Error: TFVC API call failed: {e.code} {e.reason}\nURL: {url}\nResponse: {body}"
     except urllib.error.URLError as e:
-        sys.exit(f"Error: TFVC API call failed to reach server: {e.reason}\nURL: {url}")
+        msg = f"Error: TFVC API call failed to reach server: {e.reason}\nURL: {url}"
+    if fatal:
+        sys.exit(msg)
+    print(msg, file=sys.stderr)
+    return None
 
 
 def tfvc_items_list(org, project, scope_path, recursion_level):
     """Enumerate items under a scope. Returns list of item dicts with at least 'path' and 'isFolder'."""
-    base_url = f"https://dev.azure.com/{org}/{project}/_apis/tfvc/items"
+    base_url = _tfvc_items_base_url(org, project)
     query = urllib.parse.urlencode({
         "scopePath": scope_path,
         "recursionLevel": recursion_level,
@@ -81,11 +96,13 @@ def tfvc_items_list(org, project, scope_path, recursion_level):
     return data.get("value", [])
 
 
-def tfvc_item_content(org, project, path):
-    """Fetch raw content of a single TFVC item. Returns decoded text."""
-    base_url = f"https://dev.azure.com/{org}/{project}/_apis/tfvc/items"
+def tfvc_item_content(org, project, path, *, fatal=True):
+    """Fetch raw content of a single TFVC item. Returns decoded text, or None when fatal=False and the fetch fails."""
+    base_url = _tfvc_items_base_url(org, project)
     query = urllib.parse.urlencode({"path": path, "api-version": DEFAULT_API_VERSION})
-    raw = _ado_request(f"{base_url}?{query}", "text/plain")
+    raw = _ado_request(f"{base_url}?{query}", "text/plain", fatal=fatal)
+    if raw is None:
+        return None
     return _decode_content(raw)
 
 
@@ -111,6 +128,15 @@ def mirror_lookup(mirror, mirror_prefix, tfvc_path):
     return local if local.is_file() else None
 
 
+def _paths_equal_ci(a, b):
+    """Compare TFVC paths case-insensitively and ignoring trailing slashes.
+
+    ADO normalizes scope paths in responses but the exact shape (case, trailing slash)
+    varies across endpoints and API versions — normalize both sides to be safe.
+    """
+    return a.rstrip("/").lower() == b.rstrip("/").lower()
+
+
 def cmd_ls(args):
     items = tfvc_items_list(
         args.org, args.project, args.scope,
@@ -119,7 +145,7 @@ def cmd_ls(args):
     for item in items:
         path = item.get("path", "")
         # The scope itself is included in the response — skip it to mirror 'ls' semantics.
-        if path == args.scope:
+        if _paths_equal_ci(path, args.scope):
             continue
         suffix = "/" if item.get("isFolder") else ""
         print(f"{path}{suffix}")
@@ -134,7 +160,10 @@ def cmd_read(args):
 
 
 def cmd_grep(args):
-    pattern = re.compile(args.pattern)
+    try:
+        pattern = re.compile(args.pattern)
+    except re.error as e:
+        sys.exit(f"Error: invalid regex {args.pattern!r}: {e}")
 
     # Fast path: if mirror covers the full scope, walk it directly (no REST)
     if args.mirror and args.mirror_prefix and args.scope.startswith(args.mirror_prefix):
@@ -144,7 +173,9 @@ def cmd_grep(args):
             _grep_local(root, args, pattern)
             return
 
-    # REST path: enumerate, then fetch each file, preferring mirror on a per-file basis
+    # REST path: enumerate, then fetch each file, preferring mirror on a per-file basis.
+    # Per-file failures (404 from a race, 403 on an ACL'd file) log to stderr and skip
+    # rather than aborting the whole operation — partial results beat total failure.
     items = tfvc_items_list(args.org, args.project, args.scope, "Full")
     for item in items:
         if item.get("isFolder"):
@@ -153,7 +184,12 @@ def cmd_grep(args):
         if args.file_glob and not fnmatch(Path(path).name, args.file_glob):
             continue
         local = mirror_lookup(args.mirror, args.mirror_prefix, path)
-        content = _decode_content(local.read_bytes()) if local else tfvc_item_content(args.org, args.project, path)
+        if local:
+            content = _decode_content(local.read_bytes())
+        else:
+            content = tfvc_item_content(args.org, args.project, path, fatal=False)
+            if content is None:
+                continue
         _emit_matches(path, content, pattern)
 
 

--- a/plugins/tfvc-search/scripts/tfvc-search.py
+++ b/plugins/tfvc-search/scripts/tfvc-search.py
@@ -111,9 +111,12 @@ def tfvc_item_content(org, project, path, *, fatal=True):
 
 
 def _decode_content(raw):
-    """Decode TFVC content bytes — handles UTF-8 default and UTF-16 BOM fallback for SQL scripts."""
+    """Decode TFVC content bytes — handles UTF-8 BOM, UTF-16 BOM, and raw UTF-8."""
+    # UTF-8 BOM: strip it so line-anchored regex (e.g., `^CREATE PROC`) still matches line 1.
+    if raw.startswith(b"\xef\xbb\xbf"):
+        raw = raw[3:]
+    # UTF-16 BOM (LE or BE): 'utf-16' codec autodetects endianness and strips the BOM.
     if raw.startswith((b"\xff\xfe", b"\xfe\xff")):
-        # 'utf-16' autodetects LE/BE from the BOM and strips it
         return raw.decode("utf-16", errors="replace")
     try:
         return raw.decode("utf-8")
@@ -121,24 +124,32 @@ def _decode_content(raw):
         return raw.decode("utf-8", errors="replace")
 
 
+def _paths_equal_ci(a, b):
+    """Compare TFVC paths case-insensitively and ignoring trailing slashes."""
+    return a.rstrip("/").lower() == b.rstrip("/").lower()
+
+
+def _path_is_under(inner, outer):
+    """True if `inner` is `outer` or a descendant of it, case-insensitively.
+
+    Uses a path-boundary check so that `--mirror-prefix '$/Foo'` does NOT incorrectly
+    match `--scope '$/Foobar'` — the boundary must be end-of-string or a separator.
+    """
+    inner_n = inner.rstrip("/").lower()
+    outer_n = outer.rstrip("/").lower()
+    return inner_n == outer_n or inner_n.startswith(outer_n + "/")
+
+
 def mirror_lookup(mirror, mirror_prefix, tfvc_path):
     """Return local Path for a TFVC path if the mirror has it, else None."""
     if not (mirror and mirror_prefix):
         return None
-    if not tfvc_path.startswith(mirror_prefix):
+    if not _path_is_under(tfvc_path, mirror_prefix):
         return None
-    rel = tfvc_path[len(mirror_prefix):].lstrip("/\\")
-    local = Path(mirror) / rel
+    # Strip the prefix case-insensitively — we already know the lowered form matches.
+    rel = tfvc_path[len(mirror_prefix):].lstrip("/\\") if len(tfvc_path) > len(mirror_prefix) else ""
+    local = Path(mirror) / rel if rel else Path(mirror)
     return local if local.is_file() else None
-
-
-def _paths_equal_ci(a, b):
-    """Compare TFVC paths case-insensitively and ignoring trailing slashes.
-
-    ADO normalizes scope paths in responses but the exact shape (case, trailing slash)
-    varies across endpoints and API versions — normalize both sides to be safe.
-    """
-    return a.rstrip("/").lower() == b.rstrip("/").lower()
 
 
 def cmd_ls(args):
@@ -147,7 +158,7 @@ def cmd_ls(args):
         "Full" if args.recursive else "OneLevel",
     )
     for item in items:
-        path = item.get("path", "")
+        path = item.get("path") or ""
         # The scope itself is included in the response — skip it to mirror 'ls' semantics.
         if _paths_equal_ci(path, args.scope):
             continue
@@ -169,13 +180,22 @@ def cmd_grep(args):
     except re.error as e:
         sys.exit(f"Error: invalid regex {args.pattern!r}: {e}")
 
-    # Fast path: if mirror covers the full scope, walk it directly (no REST)
-    if args.mirror and args.mirror_prefix and args.scope.startswith(args.mirror_prefix):
-        scope_rel = args.scope[len(args.mirror_prefix):].lstrip("/\\")
+    # Fast path: mirror fully covers the requested scope — walk it directly (no REST).
+    # _path_is_under enforces both case-insensitivity (TFVC is CI) and a path-segment
+    # boundary, so '$/Foo' does NOT match '$/Foobar'.
+    if args.mirror and args.mirror_prefix and _path_is_under(args.scope, args.mirror_prefix):
+        scope_rel = args.scope[len(args.mirror_prefix):].lstrip("/\\") if len(args.scope) > len(args.mirror_prefix) else ""
         root = Path(args.mirror) / scope_rel if scope_rel else Path(args.mirror)
         if root.is_dir():
             _grep_local(root, args, pattern)
             return
+        # Mirror claims to cover the scope but the directory isn't there — user
+        # probably has a stale mirror. Log once and fall through to REST.
+        print(
+            f"Warning: mirror covers '{args.scope}' by prefix but '{root}' is not a directory; "
+            "falling back to REST. (Stale mirror?)",
+            file=sys.stderr,
+        )
 
     # REST path: enumerate, then fetch each file, preferring mirror on a per-file basis.
     # Per-file failures (404 from a race, 403 on an ACL'd file) log to stderr and skip
@@ -184,7 +204,7 @@ def cmd_grep(args):
     for item in items:
         if item.get("isFolder"):
             continue
-        path = item.get("path", "")
+        path = item.get("path") or ""
         if args.file_glob and not fnmatch(Path(path).name, args.file_glob):
             continue
         local = mirror_lookup(args.mirror, args.mirror_prefix, path)
@@ -199,6 +219,7 @@ def cmd_grep(args):
 
 def _grep_local(root, args, pattern):
     """Walk a local mirror directly and emit TFVC-style paths."""
+    prefix_clean = args.mirror_prefix.rstrip("/\\")
     for dirpath, _dirs, files in os.walk(root):
         for name in files:
             if args.file_glob and not fnmatch(name, args.file_glob):
@@ -209,7 +230,7 @@ def _grep_local(root, args, pattern):
             except OSError:
                 continue
             rel = f.relative_to(args.mirror).as_posix()
-            tfvc_path = f"{args.mirror_prefix.rstrip('/')}/{rel}"
+            tfvc_path = f"{prefix_clean}/{rel}"
             _emit_matches(tfvc_path, content, pattern)
 
 
@@ -238,7 +259,7 @@ def build_parser():
         p.add_argument("--project", required=True, help="ADO project name")
         if need_scope:
             p.add_argument("--scope", required=True, help="TFVC scope path (e.g. '$/Foo/Bar')")
-        p.add_argument("--mirror", help="Optional local directory mirroring a TFVC subtree; prefer over REST when the file is present")
+        p.add_argument("--mirror", help="Optional local directory mirroring a TFVC subtree; prefer over REST when the file/scope is present")
         p.add_argument("--mirror-prefix", help="TFVC path that the mirror's root maps to (required with --mirror)")
 
     p_grep = sub.add_parser("grep", help="Recursive regex search under a TFVC scope")
@@ -263,22 +284,62 @@ def build_parser():
 def _check_msys_mangle(value, flag_name):
     """Detect MSYS/Git-Bash path mangling of TFVC '$/...' args.
 
-    MSYS rewrites '$/Foo/Bar' → '$<drive>:<mount>/Foo/Bar' before the script
-    ever sees it. The mangled form always starts with '$<letter>:' followed by
-    a slash, which is never a valid TFVC path — safe to reject.
+    Two mangling shapes:
+
+    1. '$/Foo' with the `$` surviving: MSYS rewrites to '$<drive>:<mount>/Foo'
+       (first char `$`, second is drive letter).
+    2. '$/Foo' unquoted in bash: `$` is consumed as an undefined variable expansion
+       (empty), leaving `/Foo`, which MSYS then rewrites to '<drive>:<mount>/Foo'
+       (first char drive letter — no `$` at all).
+
+    Neither is a valid TFVC path (they must start with '$/'), so any arg on a
+    TFVC-path flag starting with '[$]?<drive>:[/\\]' is safe to reject.
     """
-    if re.match(r"^\$[A-Za-z]:[\\/]", value):
+    if re.match(r"^\$?[A-Za-z]:[\\/]", value):
         sys.exit(
             f"Error: {flag_name} looks MSYS/Git-Bash-mangled: {value!r}\n"
-            f"TFVC paths must start with '$/' but MSYS rewrote yours to '$<drive>:...'.\n"
-            f"Fix: prefix the command with MSYS_NO_PATHCONV=1. Example:\n"
-            f"  MSYS_NO_PATHCONV=1 python <script> <subcommand> ..."
+            "TFVC paths must start with '$/' but the arg was rewritten to a Windows-style "
+            "path before Python received it.\n"
+            "Fix: use single-quotes around the path AND prefix the command with "
+            "MSYS_NO_PATHCONV=1. Example:\n"
+            "  MSYS_NO_PATHCONV=1 python <script> <subcommand> --scope '$/Foo/Bar' ..."
         )
+
+
+def _normalize_org(org):
+    """Extract the ADO organization name from a bare name or full URL.
+
+    Handles:
+      - 'myorg'                               → 'myorg'
+      - 'https://dev.azure.com/myorg'         → 'myorg'
+      - 'https://dev.azure.com/myorg/'        → 'myorg'
+      - 'https://dev.azure.com/myorg/project' → 'myorg' (first path segment, NOT last)
+      - 'https://myorg.visualstudio.com/'     → 'myorg' (legacy ADO URL form)
+    """
+    if not org.startswith(("http://", "https://")):
+        return org
+    parsed = urllib.parse.urlparse(org)
+    host = parsed.netloc.lower()
+    if host in ("dev.azure.com", "www.dev.azure.com"):
+        parts = [p for p in parsed.path.split("/") if p]
+        if parts:
+            return parts[0]
+    elif host.endswith(".visualstudio.com"):
+        return host[: -len(".visualstudio.com")]
+    # Unrecognized URL shape — leave as-is; the REST call will 404 and surface the mistake.
+    return org
 
 
 def main(argv=None):
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    # MSYS detection runs FIRST so users with a mangled --mirror-prefix see the
+    # specific MSYS hint rather than the generic "must be given together" error.
+    for attr in ("scope", "path", "mirror_prefix"):
+        val = getattr(args, attr, None)
+        if val:
+            _check_msys_mangle(val, f"--{attr.replace('_', '-')}")
 
     if bool(args.mirror) != bool(args.mirror_prefix):
         parser.error("--mirror and --mirror-prefix must be given together")
@@ -286,15 +347,7 @@ def main(argv=None):
     if args.mirror:
         args.mirror = args.mirror.rstrip("/\\")
 
-    # Accept either 'myorg' or 'https://dev.azure.com/myorg'
-    if args.org.startswith(("http://", "https://")):
-        args.org = args.org.rstrip("/").rsplit("/", 1)[-1]
-
-    # Catch MSYS path mangling on any TFVC-path argument before we make a REST call.
-    for attr in ("scope", "path", "mirror_prefix"):
-        val = getattr(args, attr, None)
-        if val:
-            _check_msys_mangle(val, f"--{attr.replace('_', '-')}")
+    args.org = _normalize_org(args.org)
 
     args.func(args)
 

--- a/plugins/tfvc-search/scripts/tfvc-search.py
+++ b/plugins/tfvc-search/scripts/tfvc-search.py
@@ -223,6 +223,13 @@ def build_parser():
     parser = argparse.ArgumentParser(
         prog="tfvc-search",
         description="Search and read Azure DevOps TFVC content without a local workspace.",
+        epilog=(
+            "Local mirror (much faster): add a `## TFVC Mirror` block to "
+            "~/.claude/CLAUDE.md with `Mirror path:` and `Mirror prefix:` lines, "
+            "and the /tfvc-search skill picks them up automatically. "
+            "See the plugin README for the exact format."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     sub = parser.add_subparsers(dest="cmd", required=True)
 

--- a/plugins/tfvc-search/scripts/tfvc-search.py
+++ b/plugins/tfvc-search/scripts/tfvc-search.py
@@ -15,6 +15,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import urllib.error
@@ -31,10 +32,15 @@ DEFAULT_HTTP_TIMEOUT = 30
 
 @lru_cache(maxsize=1)
 def get_access_token():
+    # Resolve via shutil.which so PATHEXT is honored on Windows — subprocess.run(["az", ...])
+    # won't find `az.cmd` by its base name alone, even though shells do.
+    az = shutil.which("az")
+    if az is None:
+        sys.exit("Error: 'az' CLI not found in PATH. Install the Azure CLI or ensure 'az' is available.")
     try:
         result = subprocess.run(
             [
-                "az", "account", "get-access-token",
+                az, "account", "get-access-token",
                 "--resource", ADO_RESOURCE_ID,
                 "--query", "accessToken",
                 "-o", "tsv",
@@ -42,8 +48,6 @@ def get_access_token():
             capture_output=True, text=True, check=True,
         )
         return result.stdout.strip()
-    except FileNotFoundError:
-        sys.exit("Error: 'az' CLI not found in PATH. Install the Azure CLI or ensure 'az' is available.")
     except subprocess.CalledProcessError as e:
         sys.exit(
             "Error: 'az account get-access-token' failed.\n"
@@ -249,6 +253,22 @@ def build_parser():
     return parser
 
 
+def _check_msys_mangle(value, flag_name):
+    """Detect MSYS/Git-Bash path mangling of TFVC '$/...' args.
+
+    MSYS rewrites '$/Foo/Bar' → '$<drive>:<mount>/Foo/Bar' before the script
+    ever sees it. The mangled form always starts with '$<letter>:' followed by
+    a slash, which is never a valid TFVC path — safe to reject.
+    """
+    if re.match(r"^\$[A-Za-z]:[\\/]", value):
+        sys.exit(
+            f"Error: {flag_name} looks MSYS/Git-Bash-mangled: {value!r}\n"
+            f"TFVC paths must start with '$/' but MSYS rewrote yours to '$<drive>:...'.\n"
+            f"Fix: prefix the command with MSYS_NO_PATHCONV=1. Example:\n"
+            f"  MSYS_NO_PATHCONV=1 python <script> <subcommand> ..."
+        )
+
+
 def main(argv=None):
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -262,6 +282,12 @@ def main(argv=None):
     # Accept either 'myorg' or 'https://dev.azure.com/myorg'
     if args.org.startswith(("http://", "https://")):
         args.org = args.org.rstrip("/").rsplit("/", 1)[-1]
+
+    # Catch MSYS path mangling on any TFVC-path argument before we make a REST call.
+    for attr in ("scope", "path", "mirror_prefix"):
+        val = getattr(args, attr, None)
+        if val:
+            _check_msys_mangle(val, f"--{attr.replace('_', '-')}")
 
     args.func(args)
 

--- a/plugins/tfvc-search/scripts/tfvc-search.py
+++ b/plugins/tfvc-search/scripts/tfvc-search.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+tfvc-search: search and read Azure DevOps TFVC content via REST.
+
+Subcommands:
+    grep   Recursive regex search under a TFVC scope path
+    read   Fetch the full content of a single TFVC item
+    ls     List files/folders under a TFVC path
+
+Auth: picks up existing `az` CLI credentials via
+`az account get-access-token --resource <ADO>`. Run `az login` first if unauthenticated.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from fnmatch import fnmatch
+from functools import lru_cache
+from pathlib import Path
+
+ADO_RESOURCE_ID = "499b84ac-1321-427f-aa17-267ca6975798"
+DEFAULT_API_VERSION = "7.1"
+
+
+@lru_cache(maxsize=1)
+def get_access_token():
+    try:
+        result = subprocess.run(
+            [
+                "az", "account", "get-access-token",
+                "--resource", ADO_RESOURCE_ID,
+                "--query", "accessToken",
+                "-o", "tsv",
+            ],
+            capture_output=True, text=True, check=True,
+        )
+        return result.stdout.strip()
+    except FileNotFoundError:
+        sys.exit("Error: 'az' CLI not found in PATH. Install the Azure CLI or ensure 'az' is available.")
+    except subprocess.CalledProcessError as e:
+        sys.exit(
+            "Error: 'az account get-access-token' failed.\n"
+            f"stderr: {e.stderr.strip()}\n"
+            "Hint: run 'az login' if you are not authenticated."
+        )
+
+
+def _ado_request(url, accept):
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {get_access_token()}",
+            "Accept": accept,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace") if e.fp else ""
+        sys.exit(f"Error: TFVC API call failed: {e.code} {e.reason}\nURL: {url}\nResponse: {body}")
+    except urllib.error.URLError as e:
+        sys.exit(f"Error: TFVC API call failed to reach server: {e.reason}\nURL: {url}")
+
+
+def tfvc_items_list(org, project, scope_path, recursion_level):
+    """Enumerate items under a scope. Returns list of item dicts with at least 'path' and 'isFolder'."""
+    base_url = f"https://dev.azure.com/{org}/{project}/_apis/tfvc/items"
+    query = urllib.parse.urlencode({
+        "scopePath": scope_path,
+        "recursionLevel": recursion_level,
+        "api-version": DEFAULT_API_VERSION,
+    })
+    data = json.loads(_ado_request(f"{base_url}?{query}", "application/json").decode("utf-8"))
+    return data.get("value", [])
+
+
+def tfvc_item_content(org, project, path):
+    """Fetch raw content of a single TFVC item. Returns decoded text."""
+    base_url = f"https://dev.azure.com/{org}/{project}/_apis/tfvc/items"
+    query = urllib.parse.urlencode({"path": path, "api-version": DEFAULT_API_VERSION})
+    raw = _ado_request(f"{base_url}?{query}", "text/plain")
+    return _decode_content(raw)
+
+
+def _decode_content(raw):
+    """Decode TFVC content bytes — handles UTF-8 default and UTF-16 BOM fallback for SQL scripts."""
+    if raw.startswith((b"\xff\xfe", b"\xfe\xff")):
+        # 'utf-16' autodetects LE/BE from the BOM and strips it
+        return raw.decode("utf-16", errors="replace")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return raw.decode("utf-8", errors="replace")
+
+
+def mirror_lookup(mirror, mirror_prefix, tfvc_path):
+    """Return local Path for a TFVC path if the mirror has it, else None."""
+    if not (mirror and mirror_prefix):
+        return None
+    if not tfvc_path.startswith(mirror_prefix):
+        return None
+    rel = tfvc_path[len(mirror_prefix):].lstrip("/\\")
+    local = Path(mirror) / rel
+    return local if local.is_file() else None
+
+
+def cmd_ls(args):
+    items = tfvc_items_list(
+        args.org, args.project, args.scope,
+        "Full" if args.recursive else "OneLevel",
+    )
+    for item in items:
+        path = item.get("path", "")
+        # The scope itself is included in the response — skip it to mirror 'ls' semantics.
+        if path == args.scope:
+            continue
+        suffix = "/" if item.get("isFolder") else ""
+        print(f"{path}{suffix}")
+
+
+def cmd_read(args):
+    local = mirror_lookup(args.mirror, args.mirror_prefix, args.path)
+    if local is not None:
+        sys.stdout.write(_decode_content(local.read_bytes()))
+        return
+    sys.stdout.write(tfvc_item_content(args.org, args.project, args.path))
+
+
+def cmd_grep(args):
+    pattern = re.compile(args.pattern)
+
+    # Fast path: if mirror covers the full scope, walk it directly (no REST)
+    if args.mirror and args.mirror_prefix and args.scope.startswith(args.mirror_prefix):
+        scope_rel = args.scope[len(args.mirror_prefix):].lstrip("/\\")
+        root = Path(args.mirror) / scope_rel if scope_rel else Path(args.mirror)
+        if root.is_dir():
+            _grep_local(root, args, pattern)
+            return
+
+    # REST path: enumerate, then fetch each file, preferring mirror on a per-file basis
+    items = tfvc_items_list(args.org, args.project, args.scope, "Full")
+    for item in items:
+        if item.get("isFolder"):
+            continue
+        path = item.get("path", "")
+        if args.file_glob and not fnmatch(Path(path).name, args.file_glob):
+            continue
+        local = mirror_lookup(args.mirror, args.mirror_prefix, path)
+        content = _decode_content(local.read_bytes()) if local else tfvc_item_content(args.org, args.project, path)
+        _emit_matches(path, content, pattern)
+
+
+def _grep_local(root, args, pattern):
+    """Walk a local mirror directly and emit TFVC-style paths."""
+    for dirpath, _dirs, files in os.walk(root):
+        for name in files:
+            if args.file_glob and not fnmatch(name, args.file_glob):
+                continue
+            f = Path(dirpath) / name
+            try:
+                content = _decode_content(f.read_bytes())
+            except OSError:
+                continue
+            rel = f.relative_to(args.mirror).as_posix()
+            tfvc_path = f"{args.mirror_prefix.rstrip('/')}/{rel}"
+            _emit_matches(tfvc_path, content, pattern)
+
+
+def _emit_matches(path, content, pattern):
+    for i, line in enumerate(content.splitlines(), start=1):
+        if pattern.search(line):
+            print(f"{path}:{i}:{line}")
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="tfvc-search",
+        description="Search and read Azure DevOps TFVC content without a local workspace.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    def add_common(p, *, need_scope):
+        p.add_argument("--org", required=True, help="ADO organization name (e.g. 'myorg') or full URL")
+        p.add_argument("--project", required=True, help="ADO project name")
+        if need_scope:
+            p.add_argument("--scope", required=True, help="TFVC scope path (e.g. '$/Foo/Bar')")
+        p.add_argument("--mirror", help="Optional local directory mirroring a TFVC subtree; prefer over REST when the file is present")
+        p.add_argument("--mirror-prefix", help="TFVC path that the mirror's root maps to (required with --mirror)")
+
+    p_grep = sub.add_parser("grep", help="Recursive regex search under a TFVC scope")
+    add_common(p_grep, need_scope=True)
+    p_grep.add_argument("--pattern", required=True, help="Python regex to search for")
+    p_grep.add_argument("--file-glob", help="Filter filenames by glob (e.g. '*.sql')")
+    p_grep.set_defaults(func=cmd_grep)
+
+    p_read = sub.add_parser("read", help="Read content of a single TFVC item")
+    add_common(p_read, need_scope=False)
+    p_read.add_argument("--path", required=True, help="TFVC item path (e.g. '$/Foo/Bar/File.sql')")
+    p_read.set_defaults(func=cmd_read)
+
+    p_ls = sub.add_parser("ls", help="List items under a TFVC path")
+    add_common(p_ls, need_scope=True)
+    p_ls.add_argument("--recursive", action="store_true", help="Recurse into subfolders")
+    p_ls.set_defaults(func=cmd_ls)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if bool(args.mirror) != bool(args.mirror_prefix):
+        parser.error("--mirror and --mirror-prefix must be given together")
+
+    if args.mirror:
+        args.mirror = args.mirror.rstrip("/\\")
+
+    # Accept either 'myorg' or 'https://dev.azure.com/myorg'
+    if args.org.startswith(("http://", "https://")):
+        args.org = args.org.rstrip("/").rsplit("/", 1)[-1]
+
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #98.

## Summary

Adds a new `tfvc-search` plugin: a Python stdlib-only wrapper around the ADO TFVC REST API that lets Claude `grep`, `read`, and `ls` source-controlled SQL (or any TFVC content) without cloning a workspace or shelling out to `TF.exe`. Auth picks up existing `az` CLI credentials, so `az login` is the only prerequisite.

- **Three subcommands:** `grep --pattern <regex> [--file-glob '*.sql']`, `read --path`, `ls --scope [--recursive]`. Output is grep-compatible (`path:line:text`) so downstream tooling / natural-language follow-ups work out of the box.
- **Optional local-mirror fast-path** (`--mirror` + `--mirror-prefix`): when the mirror covers the requested scope, the script walks the filesystem directly and skips REST entirely — orders of magnitude faster and works offline. The command markdown auto-applies these flags when the user has a `## TFVC Mirror` block in their `~/.claude/CLAUDE.md`, so they don't have to re-specify on every call.
- **Windows-first, cross-platform.** Documented as "use `MSYS_NO_PATHCONV=1` on Git Bash" to avoid the classic `$/…` → `$C:/Program Files/Git/…` mangling; the script also runtime-detects both mangling shapes and emits a clear error pointing at the fix.
- **Validated end-to-end** against a real ADO TFVC endpoint before shipping — `ls`, `read`, `grep` all confirmed working against `$/BGV Databases/RedGate/BGVTSWCustom`. Two Windows-only bugs (`subprocess.run` not finding `az.cmd`, MSYS arg mangling) were surfaced by live validation and fixed, not just papered over in tests.
- **61 unit tests**, all mock-based (no network required). Covers auth failures, URL encoding, HTTP errors, timeouts, regex errors, MSYS detection, org URL parsing, case-insensitive path matching, mirror hit/miss/stale paths, and the specific boundary-match bug where `--mirror-prefix '$/Foo'` must not match `--scope '$/Foobar'`.

## Out of scope (v1, deferred to follow-ups)

- `AZDO_PAT` env-var auth fallback (currently `az` CLI only).
- Optional live-DB companion mode — per @TimZander's comment on #98, must be strictly opt-in because reaching the live DB is a policy violation in some projects; large enough concern to warrant its own issue.
- Caching of REST responses.
- Changeset history, blame, check-ins (this plugin is read-only).

## Test plan

- [ ] Install the plugin: `/plugin install tfvc-search@tzander-skills` and confirm `/tfvc-search` appears in the skills list.
- [ ] Run `/tfvc-search what's under $/BGV Databases/RedGate/BGVTSWCustom` and verify it lists the RedGate folder structure.
- [ ] Run `/tfvc-search show me the body of $/BGV Databases/RedGate/BGVTSWCustom/Functions/asw.GetListPrice.sql` and verify clean SQL output (no BOM artifacts, no encoding garbage).
- [ ] Run `/tfvc-search find any function under $/BGV Databases/RedGate/BGVTSWCustom/Functions that references SeasonId` and verify hits are returned in `path:line:text` format.
- [ ] Add a `## TFVC Mirror` block to `~/.claude/CLAUDE.md` pointing at a local read-only mirror; re-run a recursive grep and confirm it completes much faster with no REST calls visible.
- [ ] Remove the `MSYS_NO_PATHCONV=1` prefix from a test invocation and verify the script emits the friendly MSYS-mangling error instead of hitting the API.
- [ ] Run the unit tests: `python plugins/tfvc-search/scripts/test_tfvc-search.py` — all 61 should pass.
- [ ] `/plugin uninstall tfvc-search@tzander-skills` then re-install to confirm the uninstall path is clean.