### PR TITLE
Fix #111: use cygpath -w to fix script path under MSYS_NO_PATHCONV=1

### DIFF
--- a/plugins/tfvc-search/README.md
+++ b/plugins/tfvc-search/README.md
@@ -65,7 +65,7 @@ If you only have a mirror for some subtrees, document just those — the skill f
 TFVC paths start with `$` and often contain spaces. Two rules on Bash:
 
 1. **Always single-quote the path:** `'$/BGV Databases/RedGate/BGVTSWCustom'`. Double quotes will make the shell try to expand `$/…` as a variable.
-2. **On Git Bash / MSYS, always prefix the command with `MSYS_NO_PATHCONV=1`.** Without it, MSYS rewrites `'$/Foo/Bar'` into `'$C:/Program Files/Git/Foo/Bar'` before Python receives the arg, and ADO rejects the call. The variable is harmless on non-MSYS shells, so you can always include it.
+2. **On Git Bash / MSYS, always prefix the command with `MSYS_NO_PATHCONV=1`.** Without it, MSYS rewrites `'$/Foo/Bar'` into `'$C:/Program Files/Git/Foo/Bar'` before Python receives the arg, and ADO rejects the call. The variable is harmless on non-MSYS shells, so you can always include it. **Caveat:** if you invoke via an absolute POSIX path (e.g., `/c/Users/.../tfvc-search.py`), `MSYS_NO_PATHCONV=1` also blocks translation of that path — run `cygpath -m "$SCRIPT"` first to convert it to a Windows path before disabling translation.
 
 ```bash
 MSYS_NO_PATHCONV=1 python tfvc-search.py ls \

--- a/plugins/tfvc-search/commands/tfvc-search.md
+++ b/plugins/tfvc-search/commands/tfvc-search.md
@@ -39,10 +39,13 @@ Locate the script and run the appropriate subcommand — Bash shell state does n
 ```bash
 SCRIPT=$(find ~/.claude -name tfvc-search.py -path "*/tfvc-search/*" -type f 2>/dev/null | head -1)
 [ -n "$SCRIPT" ] || { echo "tfvc-search.py not found under ~/.claude — re-install: /plugin install tfvc-search@tzander-skills" >&2; exit 1; }
+# On MSYS/Git Bash: convert the script path to a Windows path so Python can open it,
+# then block MSYS path translation for the TFVC $/... args via MSYS_NO_PATHCONV=1.
+command -v cygpath >/dev/null 2>&1 && SCRIPT=$(cygpath -w "$SCRIPT")
 MSYS_NO_PATHCONV=1 python "$SCRIPT" <subcommand> --org <ORG> --project "<PROJECT>" ...
 ```
 
-**Always prefix with `MSYS_NO_PATHCONV=1` on Windows/Git Bash.** Without it, Git Bash rewrites the TFVC `$/...` path into `$<drive>:<mount>/...` before Python receives it — the script detects this mangling and errors out clearly, but prevention is cheaper than recovery. The env var is harmless on non-MSYS shells.
+**Always prefix with `MSYS_NO_PATHCONV=1` on Windows/Git Bash.** Without it, Git Bash rewrites the TFVC `$/...` path into `$<drive>:<mount>/...` before Python receives it — the script detects this mangling and errors out clearly, but prevention is cheaper than recovery. The env var is harmless on non-MSYS shells, so it's safe to always include. The `cygpath -w` call converts the POSIX script path to a Windows path before `MSYS_NO_PATHCONV=1` disables translation — otherwise Python receives `/c/Users/...` verbatim and can't open the file.
 
 Org and project must come from the user's repo/project `CLAUDE.md` (often stored under `## SQL Database Reference` or similar), or from the user directly. Do not guess.
 
@@ -51,7 +54,7 @@ Org and project must come from the user's repo/project `CLAUDE.md` (often stored
 TFVC paths start with `$` and often contain spaces — e.g. `$/BGV Databases/RedGate/BGVTSWCustom`. In Bash:
 
 - **Always single-quote the path:** `'$/BGV Databases/RedGate/BGVTSWCustom'`. Double-quoting will make the shell try to expand `$/...` as a variable.
-- **On Git Bash / MSYS, always prefix with `MSYS_NO_PATHCONV=1`** (as shown in the invocation block above). MSYS silently rewrites args that start with `/` into Windows-style paths *before* Python receives them — so `'$/BGV Databases/...'` becomes `'$C:/Program Files/Git/BGV Databases/...'` and the ADO API rejects it with `InvalidPathException`. The env var is harmless on non-MSYS shells, so it's safe to always include.
+- **On Git Bash / MSYS, always prefix with `MSYS_NO_PATHCONV=1`** (as shown in the invocation block above). MSYS silently rewrites args that start with `/` into Windows-style paths *before* Python receives them — so `'$/BGV Databases/...'` becomes `'$C:/Program Files/Git/BGV Databases/...'` and the ADO API rejects it with `InvalidPathException`. The env var is harmless on non-MSYS shells. **Caveat:** `MSYS_NO_PATHCONV=1` also blocks translation of the script path itself, so always run `cygpath -w "$SCRIPT"` first (as shown in the invocation block) to convert it to a Windows path before disabling translation.
 
 ## Local mirror (optional, much faster)
 
@@ -67,6 +70,7 @@ If both are present in CLAUDE.md, **always pass `--mirror` and `--mirror-prefix`
 Full invocation with mirror:
 
 ```bash
+command -v cygpath >/dev/null 2>&1 && SCRIPT=$(cygpath -w "$SCRIPT")
 MSYS_NO_PATHCONV=1 python "$SCRIPT" grep \
   --org bgvone --project "BGV Databases" \
   --scope '$/BGV Databases/RedGate/BGVTSWCustom' \

--- a/plugins/tfvc-search/commands/tfvc-search.md
+++ b/plugins/tfvc-search/commands/tfvc-search.md
@@ -41,11 +41,11 @@ SCRIPT=$(find ~/.claude -name tfvc-search.py -path "*/tfvc-search/*" -type f 2>/
 [ -n "$SCRIPT" ] || { echo "tfvc-search.py not found under ~/.claude — re-install: /plugin install tfvc-search@tzander-skills" >&2; exit 1; }
 # On MSYS/Git Bash: convert the script path to a Windows path so Python can open it,
 # then block MSYS path translation for the TFVC $/... args via MSYS_NO_PATHCONV=1.
-command -v cygpath >/dev/null 2>&1 && SCRIPT=$(cygpath -w "$SCRIPT")
+command -v cygpath >/dev/null 2>&1 && { SCRIPT=$(cygpath -m "$SCRIPT") || exit 1; }
 MSYS_NO_PATHCONV=1 python "$SCRIPT" <subcommand> --org <ORG> --project "<PROJECT>" ...
 ```
 
-**Always prefix with `MSYS_NO_PATHCONV=1` on Windows/Git Bash.** Without it, Git Bash rewrites the TFVC `$/...` path into `$<drive>:<mount>/...` before Python receives it — the script detects this mangling and errors out clearly, but prevention is cheaper than recovery. The env var is harmless on non-MSYS shells, so it's safe to always include. The `cygpath -w` call converts the POSIX script path to a Windows path before `MSYS_NO_PATHCONV=1` disables translation — otherwise Python receives `/c/Users/...` verbatim and can't open the file.
+**Always prefix with `MSYS_NO_PATHCONV=1` on Windows/Git Bash.** Without it, Git Bash rewrites the TFVC `$/...` path into `$<drive>:<mount>/...` before Python receives it — the script detects this mangling and errors out clearly, but prevention is cheaper than recovery. The env var is harmless on non-MSYS shells, so it's safe to always include. The `cygpath -m` call converts the POSIX script path to a native Windows path because `MSYS_NO_PATHCONV=1` on the `python` invocation blocks all arg translation — including `$SCRIPT` — so Python would otherwise receive `/c/Users/...` verbatim and fail to open the file.
 
 Org and project must come from the user's repo/project `CLAUDE.md` (often stored under `## SQL Database Reference` or similar), or from the user directly. Do not guess.
 
@@ -54,7 +54,7 @@ Org and project must come from the user's repo/project `CLAUDE.md` (often stored
 TFVC paths start with `$` and often contain spaces — e.g. `$/BGV Databases/RedGate/BGVTSWCustom`. In Bash:
 
 - **Always single-quote the path:** `'$/BGV Databases/RedGate/BGVTSWCustom'`. Double-quoting will make the shell try to expand `$/...` as a variable.
-- **On Git Bash / MSYS, always prefix with `MSYS_NO_PATHCONV=1`** (as shown in the invocation block above). MSYS silently rewrites args that start with `/` into Windows-style paths *before* Python receives them — so `'$/BGV Databases/...'` becomes `'$C:/Program Files/Git/BGV Databases/...'` and the ADO API rejects it with `InvalidPathException`. The env var is harmless on non-MSYS shells. **Caveat:** `MSYS_NO_PATHCONV=1` also blocks translation of the script path itself, so always run `cygpath -w "$SCRIPT"` first (as shown in the invocation block) to convert it to a Windows path before disabling translation.
+- **On Git Bash / MSYS, always prefix with `MSYS_NO_PATHCONV=1`** (as shown in the invocation block above). MSYS silently rewrites args that start with `/` into Windows-style paths *before* Python receives them — so `'$/BGV Databases/...'` becomes `'$C:/Program Files/Git/BGV Databases/...'` and the ADO API rejects it with `InvalidPathException`. The env var is harmless on non-MSYS shells. **Caveat:** `MSYS_NO_PATHCONV=1` also blocks translation of the script path itself, so always run `cygpath -m "$SCRIPT"` first (as shown in the invocation block) to convert it to a native Windows path before disabling translation.
 
 ## Local mirror (optional, much faster)
 
@@ -70,7 +70,11 @@ If both are present in CLAUDE.md, **always pass `--mirror` and `--mirror-prefix`
 Full invocation with mirror:
 
 ```bash
-command -v cygpath >/dev/null 2>&1 && SCRIPT=$(cygpath -w "$SCRIPT")
+SCRIPT=$(find ~/.claude -name tfvc-search.py -path "*/tfvc-search/*" -type f 2>/dev/null | head -1)
+[ -n "$SCRIPT" ] || { echo "tfvc-search.py not found under ~/.claude — re-install: /plugin install tfvc-search@tzander-skills" >&2; exit 1; }
+# On MSYS/Git Bash: convert the script path to a Windows path so Python can open it,
+# then block MSYS path translation for the TFVC $/... args via MSYS_NO_PATHCONV=1.
+command -v cygpath >/dev/null 2>&1 && { SCRIPT=$(cygpath -m "$SCRIPT") || exit 1; }
 MSYS_NO_PATHCONV=1 python "$SCRIPT" grep \
   --org bgvone --project "BGV Databases" \
   --scope '$/BGV Databases/RedGate/BGVTSWCustom' \


### PR DESCRIPTION
## Summary

- `MSYS_NO_PATHCONV=1` is a blunt instrument — it disables MSYS path translation for **all** args, including the script path itself
- Without the fix, Python receives `/c/Users/...` verbatim and resolves it as `C:\c\Users\...` (wrong drive prefix), failing with `No such file or directory`
- Now add `command -v cygpath >/dev/null 2>&1 && SCRIPT=$(cygpath -w "$SCRIPT")` before the invocation so the script path is Windows-native when `MSYS_NO_PATHCONV=1` fires — TFVC `$/...` args still pass through unmangled

## Changes

- `plugins/tfvc-search/commands/tfvc-search.md` — both invocation blocks (basic and mirror) get the `cygpath -w` line; the footgun section's explanation updated to document the caveat

## Test plan

- [ ] On Git Bash (Windows): confirm `tfvc-search read` works without manually converting the script path
- [ ] On Linux/macOS: confirm `cygpath` is absent, the conditional is a no-op, and the skill works as before
- [ ] TFVC `$/...` paths still reach Python unmangled

Closes #111