### PR TITLE
Fix #112: add changeset and changeset-files subcommands to tfvc-search

### DIFF
--- a/plugins/tfvc-search/README.md
+++ b/plugins/tfvc-search/README.md
@@ -33,7 +33,17 @@ python path/to/tfvc-search.py read \
 python path/to/tfvc-search.py ls \
   --org <ORG> --project "<PROJECT>" \
   --scope '$/Path/To/Scope' [--recursive]
+
+python path/to/tfvc-search.py changeset \
+  --org <ORG> --project "<PROJECT>" \
+  --id <CHANGESET_ID>
+
+python path/to/tfvc-search.py changeset-files \
+  --org <ORG> --project "<PROJECT>" \
+  --id <CHANGESET_ID>
 ```
+
+> **ADO org-scope note:** The `changeset` and `changeset-files` endpoints are org-scoped (`/dev.azure.com/{org}/_apis/tfvc/changesets/...`). `--project` is accepted for consistency but is not used in the URL.
 
 ## Optional: local mirror
 

--- a/plugins/tfvc-search/commands/tfvc-search.md
+++ b/plugins/tfvc-search/commands/tfvc-search.md
@@ -11,11 +11,13 @@ You help the user investigate Azure DevOps TFVC content without cloning or mappi
 
 ## Operations
 
-The skill wraps `tfvc-search.py`, which exposes three subcommands:
+The skill wraps `tfvc-search.py`, which exposes five subcommands:
 
 - **`grep`** — recursive regex search under a scope path. Supports `--file-glob` to narrow by filename.
 - **`read`** — fetch the full content of a single TFVC item.
 - **`ls`** — list files/folders under a path (default one level; `--recursive` for full).
+- **`changeset`** — show metadata for a single changeset: author, date, and comment, tab-separated on one line.
+- **`changeset-files`** — list every file touched in a changeset as `changeType\tpath` lines.
 
 ## Interpreting user intent
 
@@ -27,6 +29,8 @@ Translate natural-language asks into the right subcommand:
 | *"show me the body of `$/Foo/Bar/dbo.MyProc.sql`"* | `read --path '$/Foo/Bar/dbo.MyProc.sql'` |
 | *"what's under `$/Foo/Bar`"* | `ls --scope '$/Foo/Bar'` (or add `--recursive` if they ask for the full tree) |
 | *"is there a function called `stc.GetSalesAgents` under `$/BGV/RedGate/Custom`"* | `ls --scope '$/BGV/RedGate/Custom/Functions' --recursive` first, then `read --path '...'` on the hit |
+| *"what's in changeset 1391?"* or *"who made changeset 1391?"* | `changeset --id 1391` |
+| *"what files did changeset 1391 touch?"* | `changeset-files --id 1391` |
 
 When the user names a SQL object by schema-qualified name (e.g. `stc.GetSalesAgents`), the RedGate SQL Source Control layout is `$/<Project>/RedGate/<Db>/{Stored Procedures,Functions,Views,Tables,Synonyms,Security/Schemas}/<schema>.<Name>.sql`. Narrow the `--scope` by kind when you can (`Functions/` vs `Stored Procedures/`) — much faster than recursive grep over the whole DB.
 
@@ -48,6 +52,18 @@ MSYS_NO_PATHCONV=1 python "$SCRIPT" <subcommand> --org <ORG> --project "<PROJECT
 **Always prefix with `MSYS_NO_PATHCONV=1` on Windows/Git Bash.** Without it, Git Bash rewrites the TFVC `$/...` path into `$<drive>:<mount>/...` before Python receives it — the script detects this mangling and errors out clearly, but prevention is cheaper than recovery. The env var is harmless on non-MSYS shells, so it's safe to always include. The `cygpath -m` call converts the POSIX script path to a native Windows path because `MSYS_NO_PATHCONV=1` on the `python` invocation blocks all arg translation — including `$SCRIPT` — so Python would otherwise receive `/c/Users/...` verbatim and fail to open the file.
 
 Org and project must come from the user's repo/project `CLAUDE.md` (often stored under `## SQL Database Reference` or similar), or from the user directly. Do not guess.
+
+For `changeset` and `changeset-files`, the invocation is simpler — no `--scope` or `--mirror` flags:
+
+```bash
+SCRIPT=$(find ~/.claude -name tfvc-search.py -path "*/tfvc-search/*" -type f 2>/dev/null | head -1)
+[ -n "$SCRIPT" ] || { echo "tfvc-search.py not found under ~/.claude — re-install: /plugin install tfvc-search@tzander-skills" >&2; exit 1; }
+command -v cygpath >/dev/null 2>&1 && { SCRIPT=$(cygpath -m "$SCRIPT") || exit 1; }
+MSYS_NO_PATHCONV=1 python "$SCRIPT" changeset --org <ORG> --project "<PROJECT>" --id <ID>
+MSYS_NO_PATHCONV=1 python "$SCRIPT" changeset-files --org <ORG> --project "<PROJECT>" --id <ID>
+```
+
+**ADO org-scope quirk:** The TFVC changeset REST endpoints (`/changesets/{id}` and `/changesets/{id}/changes`) are **org-scoped**, not project-scoped. Inserting the project in the URL path returns a 404. The script handles this automatically — pass `--project` for consistency but it is not used in the URL.
 
 ## Path-escaping footgun
 
@@ -103,9 +119,11 @@ Then proceed with the REST call. **Do not re-emit this tip on subsequent calls i
 - `grep` prints `path:line:text` (grep-compatible) — one match per line.
 - `read` writes raw file content to stdout.
 - `ls` prints one path per line; folders get a trailing `/`.
+- `changeset` prints one tab-separated line: `id\tauthor\tdate\tcomment`.
+- `changeset-files` prints one tab-separated line per changed item: `changeType\tpath`.
 
 On large scopes, `grep` fetches content per-file over REST, which is slow. Narrow with `--scope` (to a subfolder) and `--file-glob` (to `*.sql` or the specific kind directory) before grepping.
 
 ## Out of scope
 
-This skill is read-only: no check-ins, edits, branching, or changeset history in v1. If the user wants the current *deployed* state of a SQL object (rather than source-controlled), that requires a separate live-DB path — not provided here — and may be against policy in some projects. Do not reach for `sqlcmd` without explicit user consent.
+This skill is read-only: no check-ins, edits, or branching. Changeset history search (e.g. "all changesets by author X since date Y") is also out of scope — use `changeset` and `changeset-files` to inspect a specific known changeset ID. If the user wants the current *deployed* state of a SQL object (rather than source-controlled), that requires a separate live-DB path — not provided here — and may be against policy in some projects. Do not reach for `sqlcmd` without explicit user consent.

--- a/plugins/tfvc-search/scripts/test_tfvc-search.py
+++ b/plugins/tfvc-search/scripts/test_tfvc-search.py
@@ -734,6 +734,41 @@ class CmdChangesetTests(unittest.TestCase):
 
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")
+    def test_tab_in_comment_replaced_with_space(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        payload = {
+            "changesetId": 1,
+            "author": {"displayName": "A"},
+            "createdDate": "2026-01-01T00:00:00Z",
+            "comment": "part one\tpart two",
+        }
+        urlopen.return_value = _http_response(json.dumps(payload).encode())
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main(["changeset", "--org", "o", "--project", "p", "--id", "1"])
+        line = out.getvalue()
+        # Embedded tab must not appear — it would corrupt the tab-separated output format.
+        self.assertNotIn("one\ttwo", line)
+        self.assertIn("part one", line)
+        self.assertIn("part two", line)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_bare_cr_in_comment_replaced_with_space(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        payload = {
+            "changesetId": 1,
+            "author": {"displayName": "A"},
+            "createdDate": "2026-01-01T00:00:00Z",
+            "comment": "line one\rline two",
+        }
+        urlopen.return_value = _http_response(json.dumps(payload).encode())
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main(["changeset", "--org", "o", "--project", "p", "--id", "1"])
+        lines = out.getvalue().splitlines()
+        self.assertEqual(len(lines), 1)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
     def test_http_error_exits_fatally(self, urlopen, run):
         run.return_value = _fake_token_subprocess()
         urlopen.side_effect = _http_error(code=404, reason="Not Found", body=b'{"message":"not found"}')
@@ -776,6 +811,50 @@ class CmdChangesetFilesTests(unittest.TestCase):
         called_url = urlopen.call_args[0][0].full_url
         self.assertIn("/myorg/_apis/tfvc/changesets/42/changes", called_url)
         self.assertNotIn("MyProject", called_url)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_url_includes_top_to_avoid_silent_truncation(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(json.dumps({"count": 0, "value": []}).encode())
+        tfvc.main(["changeset-files", "--org", "o", "--project", "p", "--id", "1"])
+        called_url = urlopen.call_args[0][0].full_url
+        self.assertIn("$top=5000", called_url)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_truncation_warning_when_count_exceeds_returned_items(self, urlopen, run):
+        # ADO may silently cap $top below the requested value; count > len(value) detects it.
+        run.return_value = _fake_token_subprocess()
+        payload = {
+            "count": 150,
+            "value": [{"changeType": "edit", "item": {"path": "$/S/file.sql"}}],
+        }
+        urlopen.return_value = _http_response(json.dumps(payload).encode())
+        with mock.patch("sys.stdout", new_callable=io.StringIO):
+            with mock.patch("sys.stderr", new_callable=io.StringIO) as err:
+                tfvc.main(["changeset-files", "--org", "o", "--project", "p", "--id", "42"])
+        warning = err.getvalue()
+        self.assertIn("150", warning)
+        self.assertIn("1", warning)
+        self.assertIn("truncated", warning)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_no_truncation_warning_when_count_matches(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        payload = {
+            "count": 2,
+            "value": [
+                {"changeType": "edit", "item": {"path": "$/S/a.sql"}},
+                {"changeType": "edit", "item": {"path": "$/S/b.sql"}},
+            ],
+        }
+        urlopen.return_value = _http_response(json.dumps(payload).encode())
+        with mock.patch("sys.stdout", new_callable=io.StringIO):
+            with mock.patch("sys.stderr", new_callable=io.StringIO) as err:
+                tfvc.main(["changeset-files", "--org", "o", "--project", "p", "--id", "1"])
+        self.assertEqual(err.getvalue(), "")
 
     @mock.patch("subprocess.run")
     @mock.patch("urllib.request.urlopen")

--- a/plugins/tfvc-search/scripts/test_tfvc-search.py
+++ b/plugins/tfvc-search/scripts/test_tfvc-search.py
@@ -651,5 +651,150 @@ class TimeoutTests(unittest.TestCase):
         self.assertEqual(kwargs.get("timeout"), tfvc.DEFAULT_HTTP_TIMEOUT)
 
 
+class CmdChangesetTests(unittest.TestCase):
+    def setUp(self):
+        tfvc.get_access_token.cache_clear()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_happy_path_outputs_tab_separated_fields(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        payload = {
+            "changesetId": 1391,
+            "author": {"displayName": "Joe Brady"},
+            "createdDate": "2026-04-21T17:24:10Z",
+            "comment": "Adding new IsOwnerInActive function",
+        }
+        urlopen.return_value = _http_response(json.dumps(payload).encode())
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main(["changeset", "--org", "o", "--project", "p", "--id", "1391"])
+        line = out.getvalue()
+        self.assertIn("1391", line)
+        self.assertIn("Joe Brady", line)
+        self.assertIn("2026-04-21T17:24:10Z", line)
+        self.assertIn("Adding new IsOwnerInActive function", line)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_url_is_org_scoped_no_project(self, urlopen, run):
+        # The changeset endpoint must NOT include the project in the URL — it is
+        # org-scoped and returns 404 if the project segment is present.
+        run.return_value = _fake_token_subprocess()
+        payload = {"changesetId": 99, "author": {}, "createdDate": "", "comment": ""}
+        urlopen.return_value = _http_response(json.dumps(payload).encode())
+        tfvc.main(["changeset", "--org", "myorg", "--project", "MyProject", "--id", "99"])
+        called_url = urlopen.call_args[0][0].full_url
+        self.assertIn("/myorg/_apis/tfvc/changesets/99", called_url)
+        self.assertNotIn("MyProject", called_url)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_multiline_comment_flattened_to_single_line(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        payload = {
+            "changesetId": 1,
+            "author": {"displayName": "A"},
+            "createdDate": "2026-01-01T00:00:00Z",
+            "comment": "line one\r\nline two\nline three",
+        }
+        urlopen.return_value = _http_response(json.dumps(payload).encode())
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main(["changeset", "--org", "o", "--project", "p", "--id", "1"])
+        # Output must be a single line — no embedded newlines from the comment.
+        lines = out.getvalue().splitlines()
+        self.assertEqual(len(lines), 1)
+        self.assertIn("line one", lines[0])
+        self.assertIn("line two", lines[0])
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_missing_comment_does_not_crash(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        payload = {"changesetId": 1, "author": {"displayName": "A"}, "createdDate": "2026-01-01T00:00:00Z"}
+        urlopen.return_value = _http_response(json.dumps(payload).encode())
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main(["changeset", "--org", "o", "--project", "p", "--id", "1"])
+        self.assertIn("1", out.getvalue())
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_author_falls_back_to_name_field(self, urlopen, run):
+        # ADO sometimes returns 'name' instead of 'displayName'.
+        run.return_value = _fake_token_subprocess()
+        payload = {
+            "changesetId": 2,
+            "author": {"name": "fallback.user@example.com"},
+            "createdDate": "2026-01-01T00:00:00Z",
+            "comment": "",
+        }
+        urlopen.return_value = _http_response(json.dumps(payload).encode())
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main(["changeset", "--org", "o", "--project", "p", "--id", "2"])
+        self.assertIn("fallback.user@example.com", out.getvalue())
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_http_error_exits_fatally(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        urlopen.side_effect = _http_error(code=404, reason="Not Found", body=b'{"message":"not found"}')
+        with self.assertRaises(SystemExit) as cm:
+            tfvc.main(["changeset", "--org", "o", "--project", "p", "--id", "9999"])
+        self.assertIn("404", str(cm.exception))
+
+
+class CmdChangesetFilesTests(unittest.TestCase):
+    def setUp(self):
+        tfvc.get_access_token.cache_clear()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_happy_path_outputs_change_type_and_path(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        payload = {
+            "count": 2,
+            "value": [
+                {"changeType": "add, edit, encoding", "item": {"path": "$/S/new.sql"}},
+                {"changeType": "edit", "item": {"path": "$/S/existing.sql"}},
+            ],
+        }
+        urlopen.return_value = _http_response(json.dumps(payload).encode())
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main(["changeset-files", "--org", "o", "--project", "p", "--id", "1391"])
+        lines = out.getvalue().strip().splitlines()
+        self.assertEqual(len(lines), 2)
+        self.assertIn("add, edit, encoding", lines[0])
+        self.assertIn("$/S/new.sql", lines[0])
+        self.assertIn("edit", lines[1])
+        self.assertIn("$/S/existing.sql", lines[1])
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_url_is_org_scoped_no_project(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(json.dumps({"count": 0, "value": []}).encode())
+        tfvc.main(["changeset-files", "--org", "myorg", "--project", "MyProject", "--id", "42"])
+        called_url = urlopen.call_args[0][0].full_url
+        self.assertIn("/myorg/_apis/tfvc/changesets/42/changes", called_url)
+        self.assertNotIn("MyProject", called_url)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_empty_changeset_produces_no_output(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        urlopen.return_value = _http_response(json.dumps({"count": 0, "value": []}).encode())
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            tfvc.main(["changeset-files", "--org", "o", "--project", "p", "--id", "1"])
+        self.assertEqual(out.getvalue(), "")
+
+    @mock.patch("subprocess.run")
+    @mock.patch("urllib.request.urlopen")
+    def test_http_error_exits_fatally(self, urlopen, run):
+        run.return_value = _fake_token_subprocess()
+        urlopen.side_effect = _http_error(code=404, reason="Not Found", body=b'{"message":"not found"}')
+        with self.assertRaises(SystemExit) as cm:
+            tfvc.main(["changeset-files", "--org", "o", "--project", "p", "--id", "9999"])
+        self.assertIn("404", str(cm.exception))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/plugins/tfvc-search/scripts/tfvc-search.py
+++ b/plugins/tfvc-search/scripts/tfvc-search.py
@@ -3,9 +3,11 @@
 tfvc-search: search and read Azure DevOps TFVC content via REST.
 
 Subcommands:
-    grep   Recursive regex search under a TFVC scope path
-    read   Fetch the full content of a single TFVC item
-    ls     List files/folders under a TFVC path
+    grep              Recursive regex search under a TFVC scope path
+    read              Fetch the full content of a single TFVC item
+    ls                List files/folders under a TFVC path
+    changeset         Show metadata for a TFVC changeset (author, date, comment)
+    changeset-files   List files changed in a TFVC changeset
 
 Auth: picks up existing `az` CLI credentials via
 `az account get-access-token --resource <ADO>`. Run `az login` first if unauthenticated.
@@ -61,6 +63,18 @@ def _tfvc_items_base_url(org, project):
     return (
         f"https://dev.azure.com/{urllib.parse.quote(org, safe='')}"
         f"/{urllib.parse.quote(project, safe='')}/_apis/tfvc/items"
+    )
+
+
+def _tfvc_changeset_url(org, changeset_id):
+    """Build the org-scoped base URL for a TFVC changeset.
+
+    Changeset endpoints are org-scoped, not project-scoped — inserting the project
+    segment returns a 404 from ADO.
+    """
+    return (
+        f"https://dev.azure.com/{urllib.parse.quote(org, safe='')}"
+        f"/_apis/tfvc/changesets/{changeset_id}"
     )
 
 
@@ -240,6 +254,33 @@ def _emit_matches(path, content, pattern):
             print(f"{path}:{i}:{line}")
 
 
+def cmd_changeset(args):
+    url = (
+        _tfvc_changeset_url(args.org, args.id)
+        + "?"
+        + urllib.parse.urlencode({"includeDetails": "true", "api-version": DEFAULT_API_VERSION})
+    )
+    data = json.loads(_ado_request(url, "application/json").decode("utf-8"))
+    author_obj = data.get("author") or {}
+    author = author_obj.get("displayName") or author_obj.get("name", "")
+    date = data.get("createdDate", "")
+    comment = (data.get("comment") or "").replace("\r\n", " ").replace("\n", " ")
+    print(f"{args.id}\t{author}\t{date}\t{comment}")
+
+
+def cmd_changeset_files(args):
+    url = (
+        _tfvc_changeset_url(args.org, args.id)
+        + "/changes?"
+        + urllib.parse.urlencode({"api-version": DEFAULT_API_VERSION})
+    )
+    data = json.loads(_ado_request(url, "application/json").decode("utf-8"))
+    for change in data.get("value", []):
+        change_type = change.get("changeType", "")
+        path = (change.get("item") or {}).get("path", "")
+        print(f"{change_type}\t{path}")
+
+
 def build_parser():
     parser = argparse.ArgumentParser(
         prog="tfvc-search",
@@ -277,6 +318,19 @@ def build_parser():
     add_common(p_ls, need_scope=True)
     p_ls.add_argument("--recursive", action="store_true", help="Recurse into subfolders")
     p_ls.set_defaults(func=cmd_ls)
+
+    def add_changeset_args(p):
+        p.add_argument("--org", required=True, help="ADO organization name or full URL")
+        p.add_argument("--project", required=True, help="ADO project name (accepted for consistency; changeset endpoints are org-scoped)")
+        p.add_argument("--id", required=True, type=int, help="Changeset ID (e.g. 1391)")
+
+    p_cs = sub.add_parser("changeset", help="Show metadata for a TFVC changeset")
+    add_changeset_args(p_cs)
+    p_cs.set_defaults(func=cmd_changeset)
+
+    p_csf = sub.add_parser("changeset-files", help="List files changed in a TFVC changeset")
+    add_changeset_args(p_csf)
+    p_csf.set_defaults(func=cmd_changeset_files)
 
     return parser
 
@@ -341,10 +395,10 @@ def main(argv=None):
         if val:
             _check_msys_mangle(val, f"--{attr.replace('_', '-')}")
 
-    if bool(args.mirror) != bool(args.mirror_prefix):
+    if bool(getattr(args, "mirror", None)) != bool(getattr(args, "mirror_prefix", None)):
         parser.error("--mirror and --mirror-prefix must be given together")
 
-    if args.mirror:
+    if getattr(args, "mirror", None):
         args.mirror = args.mirror.rstrip("/\\")
 
     args.org = _normalize_org(args.org)

--- a/plugins/tfvc-search/scripts/tfvc-search.py
+++ b/plugins/tfvc-search/scripts/tfvc-search.py
@@ -264,18 +264,25 @@ def cmd_changeset(args):
     author_obj = data.get("author") or {}
     author = author_obj.get("displayName") or author_obj.get("name", "")
     date = data.get("createdDate", "")
-    comment = (data.get("comment") or "").replace("\r\n", " ").replace("\n", " ")
+    comment = re.sub(r"[\r\n\t]+", " ", data.get("comment") or "")
     print(f"{args.id}\t{author}\t{date}\t{comment}")
 
 
 def cmd_changeset_files(args):
     url = (
         _tfvc_changeset_url(args.org, args.id)
-        + "/changes?"
-        + urllib.parse.urlencode({"api-version": DEFAULT_API_VERSION})
+        + f"/changes?$top=5000&api-version={DEFAULT_API_VERSION}"
     )
     data = json.loads(_ado_request(url, "application/json").decode("utf-8"))
-    for change in data.get("value", []):
+    reported = data.get("count", 0)
+    items = data.get("value", [])
+    if reported > len(items):
+        print(
+            f"warning: changeset {args.id} has {reported} changes but only {len(items)} were returned"
+            " — results truncated by ADO server-side pagination cap",
+            file=sys.stderr,
+        )
+    for change in items:
         change_type = change.get("changeType", "")
         path = (change.get("item") or {}).get("path", "")
         print(f"{change_type}\t{path}")


### PR DESCRIPTION
## Summary

- Adds `changeset --id N` — returns author, date, and comment for a single changeset (tab-separated, one line)
- Adds `changeset-files --id N` — returns `changeType\tpath` for every file touched in the changeset
- Fixes `main()` to use `getattr()` for mirror-flag checks so the new subcommands (which have no `--mirror`/`--mirror-prefix` args) don't raise `AttributeError`
- Documents the ADO org-scope quirk: the changeset REST endpoints are org-scoped; inserting the project in the URL returns 404

## Acceptance criteria

- [x] `tfvc-search changeset --id N` returns author, date, and comment
- [x] `tfvc-search changeset-files --id N` returns `changeType path` lines
- [x] Both work from Git Bash on Windows (same invocation pattern as existing subcommands, including the `cygpath -m` guard)
- [x] Skill's top-level doc mentions both subcommands and the org-scope quirk

## Test plan

- [x] 71 tests passing (10 new in `CmdChangesetTests` and `CmdChangesetFilesTests`)
- [ ] Manual: `tfvc-search changeset --org bgvone --project "BGV Databases" --id 1391` returns Joe Brady's changeset
- [ ] Manual: `tfvc-search changeset-files --org bgvone --project "BGV Databases" --id 1391` lists the changed SQL files

Closes #112