### PR TITLE
Add BSD diff fallback for setup-env.sh standards preview

### DIFF
--- a/scripts/diff-preview.awk
+++ b/scripts/diff-preview.awk
@@ -1,0 +1,16 @@
+# Reformat `diff -u` output into the "Changes:" preview style used by
+# setup-env.sh when reporting what team-standards changes were applied.
+#
+# Input: standard unified-diff (`diff -u OLD NEW`).
+# Output: one line per changed input line, prefixed `  + ` (added) or `  - `
+# (removed). Context and hunk markers are suppressed.
+#
+# NR <= 2 drops the `--- file1` / `+++ file2` headers by position rather than
+# by regex. A regex like `/^--- /` would false-match a deleted content line
+# whose text began with `-- ` (the diff would render it as `--- ...`) and
+# silently eat that change from the preview. Position-based skipping is safe
+# because unified-diff always emits exactly those two header lines first.
+NR <= 2 { next }
+/^@@/ { next }
+/^-/ { print "  - " substr($0, 2); next }
+/^\+/ { print "  + " substr($0, 2); next }

--- a/scripts/test_setup-env.sh
+++ b/scripts/test_setup-env.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Smoke test for setup-env.sh's BSD/macOS diff-preview fallback.
+#
+# What's covered: the extracted awk program at scripts/diff-preview.awk,
+# which is the logic that can diverge between GNU and BSD diff output.
+# Fixtures include the regression case (a deleted content line beginning
+# with `-- ` that would false-match the unified-diff header regex before
+# the NR-based fix).
+#
+# What's NOT covered: the GNU-vs-BSD detection probe at setup-env.sh:141
+# (requires a mock `diff` that rejects --*-line-format flags). Test that
+# manually by running the script on each platform.
+#
+# Invoke: bash scripts/test_setup-env.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SETUP_ENV="$REPO_ROOT/setup-env.sh"
+AWK_SCRIPT="$SCRIPT_DIR/diff-preview.awk"
+
+fail=0
+pass=0
+
+# All fixtures write into a temp dir; clean it up regardless of exit path.
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+assert_equal() {
+    local want="$1" got="$2" label="$3"
+    if [ "$want" = "$got" ]; then
+        pass=$((pass + 1))
+        echo "  PASS $label"
+    else
+        fail=$((fail + 1))
+        echo "  FAIL $label"
+        printf '    want: %q\n' "$want"
+        printf '    got:  %q\n' "$got"
+    fi
+}
+
+# Run `diff -u OLD NEW` and pipe through the extracted awk preview script.
+run_preview() {
+    local old="$1" new="$2"
+    { diff -u "$old" "$new" || true; } | awk -f "$AWK_SCRIPT"
+}
+
+echo "1) setup-env.sh parses as valid bash"
+if bash -n "$SETUP_ENV"; then
+    pass=$((pass + 1)); echo "  PASS bash -n parses setup-env.sh"
+else
+    fail=$((fail + 1)); echo "  FAIL bash -n reported a syntax error"
+fi
+
+echo "2) happy path: one addition and one deletion"
+printf 'alpha\nbeta\ngamma\n' > "$TEST_TMPDIR/old.txt"
+printf 'alpha\ndelta\ngamma\n' > "$TEST_TMPDIR/new.txt"
+got="$(run_preview "$TEST_TMPDIR/old.txt" "$TEST_TMPDIR/new.txt")"
+want="  - beta
+  + delta"
+assert_equal "$want" "$got" "addition + deletion formatted with   -  /   +  prefixes"
+
+echo "3) regression: deletion of a line starting with '-- ' is not swallowed"
+# Before the fix the awk regex /^--- / matched the diff's rendering of this
+# deletion (the `-` prefix plus the content `-- comment` yields `--- comment`)
+# and silently dropped it — the preview would show nothing for this change.
+printf 'keep\n-- comment\ntail\n' > "$TEST_TMPDIR/old.txt"
+printf 'keep\ntail\n' > "$TEST_TMPDIR/new.txt"
+got="$(run_preview "$TEST_TMPDIR/old.txt" "$TEST_TMPDIR/new.txt")"
+want="  - -- comment"
+assert_equal "$want" "$got" "deletion of '-- comment' surfaces in preview"
+
+echo "4) regression: addition of a line starting with '++ ' is not swallowed"
+# Symmetric case — `/^\+\+\+ /` would false-match a new line whose content
+# began with `++ ` (rendered as `+++ ` in the diff).
+printf 'keep\ntail\n' > "$TEST_TMPDIR/old.txt"
+printf 'keep\n++ addition\ntail\n' > "$TEST_TMPDIR/new.txt"
+got="$(run_preview "$TEST_TMPDIR/old.txt" "$TEST_TMPDIR/new.txt")"
+want="  + ++ addition"
+assert_equal "$want" "$got" "addition of '++ addition' surfaces in preview"
+
+echo "5) context lines are dropped (only +/- lines are emitted)"
+# diff -u emits 3 lines of context around each hunk by default. The preview
+# must not include those unchanged lines.
+printf 'one\ntwo\nthree\nfour\nfive\n' > "$TEST_TMPDIR/old.txt"
+printf 'one\ntwo\nTHREE\nfour\nfive\n' > "$TEST_TMPDIR/new.txt"
+got="$(run_preview "$TEST_TMPDIR/old.txt" "$TEST_TMPDIR/new.txt")"
+want="  - three
+  + THREE"
+assert_equal "$want" "$got" "unchanged context lines are suppressed"
+
+echo "6) identical files produce empty preview"
+printf 'same\ncontent\n' > "$TEST_TMPDIR/old.txt"
+printf 'same\ncontent\n' > "$TEST_TMPDIR/new.txt"
+got="$(run_preview "$TEST_TMPDIR/old.txt" "$TEST_TMPDIR/new.txt")"
+assert_equal "" "$got" "no output when files match"
+
+echo "7) hunk markers (@@) are not emitted"
+# Trigger a multi-hunk diff so at least one @@ line is present, then check
+# that the preview contains no '@@' substrings.
+printf 'a1\na2\na3\na4\na5\na6\na7\na8\na9\nb1\nb2\nb3\nb4\nb5\nb6\nb7\nb8\nb9\n' > "$TEST_TMPDIR/old.txt"
+printf 'A1\na2\na3\na4\na5\na6\na7\na8\na9\nb1\nb2\nb3\nb4\nb5\nb6\nb7\nb8\nB9\n' > "$TEST_TMPDIR/new.txt"
+got="$(run_preview "$TEST_TMPDIR/old.txt" "$TEST_TMPDIR/new.txt")"
+case "$got" in
+    *"@@"*) fail=$((fail + 1)); echo "  FAIL preview leaked an @@ hunk marker"; echo "    got: $got" ;;
+    *) pass=$((pass + 1)); echo "  PASS no @@ markers in preview" ;;
+esac
+
+echo ""
+echo "Passed: $pass  Failed: $fail"
+[ "$fail" -eq 0 ]

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -138,10 +138,16 @@ ${END_MARKER}"
             NEW_SECTION_FILE="$(mktemp)"
             printf '%s\n' "$STANDARDS_CONTENT" > "$NEW_SECTION_FILE"
             echo "Changes:"
-            diff "$OLD_SECTION_FILE" "$NEW_SECTION_FILE" \
-                --old-line-format='  - %L' \
-                --new-line-format='  + %L' \
-                --unchanged-line-format='' || true
+            if diff --old-line-format='' --new-line-format='' --unchanged-line-format='' /dev/null /dev/null >/dev/null 2>&1; then
+                diff "$OLD_SECTION_FILE" "$NEW_SECTION_FILE" \
+                    --old-line-format='  - %L' \
+                    --new-line-format='  + %L' \
+                    --unchanged-line-format='' || true
+            else
+                # BSD diff (macOS) lacks --*-line-format; post-process a unified diff instead.
+                { diff -u "$OLD_SECTION_FILE" "$NEW_SECTION_FILE" || true; } \
+                    | awk -f "$REPO_ROOT/scripts/diff-preview.awk"
+            fi
             rm -f "$NEW_SECTION_FILE"
 
             printf '%s' "$UPDATED_CONTENT" > "$TARGET_FILE"


### PR DESCRIPTION
## Summary

- `setup-env.sh`'s "Changes:" preview used GNU-only `--old-line-format` / `--new-line-format` / `--unchanged-line-format` flags; BSD diff (macOS default) rejects them with exit 2. Added a flag-support probe and an awk-based fallback that reformats `diff -u` output into the same `  - ` / `  + ` preview style.
- Fixed a latent regex bug in the fallback: `/^--- / || /^\+\+\+ /` false-matched content lines whose original text began with `-- ` or `++ ` (rendered as `--- ...` / `+++ ...` in the unified diff), silently dropping them from the preview. Switched to `NR <= 2` position-based header skipping, which is safe because unified-diff always emits exactly those two header lines first.
- Extracted the awk program to `scripts/diff-preview.awk` so it has a single source of truth and can be tested in isolation.
- Added `scripts/test_setup-env.sh` — 7 smoke tests covering the regression cases, happy path, context-line suppression, identical-files, and hunk-marker suppression. Follows the existing `plugins/*/scripts/test_*.sh` style.

## Test plan

- [x] `bash scripts/test_setup-env.sh` → 7/7 pass on macOS (BSD diff)
- [x] `bash -n setup-env.sh` → syntax clean
- [x] Manual: delete a line starting with `-- ` from `standards/CLAUDE.md`, run `./setup-env.sh`, confirm the deletion now appears in the "Changes:" preview (was silently dropped before)
- [ ] Manual (Linux / Git Bash): confirm GNU path still runs unchanged — the detection probe should select the GNU branch

## Not covered

- No automated test for the GNU-vs-BSD detection probe itself — that requires a mock `diff` binary and is flagged as a manual verification step in the test file header.