### PR TITLE
Polish investigate-appinsights-logs from first real use (#119)

### DIFF
--- a/plugins/investigate-appinsights-logs/README.md
+++ b/plugins/investigate-appinsights-logs/README.md
@@ -59,7 +59,7 @@ Some KQL files/blocks in a repo are meant for manual copy-paste (they have hardc
 ```kql
 // @skill-skip date-pinned helper — edit the datetime literals before running manually
 let cycleTime = datetime(2026-04-10T23:00:15Z);
-let caicWindow = datetime(2026-04-10T22:30:00Z);
+let providerWindow = datetime(2026-04-10T22:30:00Z);
 ...
 ```
 

--- a/plugins/investigate-appinsights-logs/README.md
+++ b/plugins/investigate-appinsights-logs/README.md
@@ -52,6 +52,19 @@ CLI flags override config. Notes:
 - `--health-url`: one-shot snapshot URL (may come from config).
 - `--queries <glob>`: restrict query discovery to matching paths.
 
+## Skipping analytical-helper queries
+
+Some KQL files/blocks in a repo are meant for manual copy-paste (they have hardcoded `datetime(...)` literals, `let`-bindings with specific times, etc.) and should not run as-is against the current time window. Mark them with a `// @skill-skip` comment on the first non-blank line of the query body:
+
+```kql
+// @skill-skip date-pinned helper — edit the datetime literals before running manually
+let cycleTime = datetime(2026-04-10T23:00:15Z);
+let caicWindow = datetime(2026-04-10T22:30:00Z);
+...
+```
+
+The skill still discovers these queries and lists them in the per-query findings table as `[SKIPPED: <reason>]`, but does not submit them to App Insights. The reason after `@skill-skip` is free-form; omit it and the annotation reads `[SKIPPED: author-marked]`.
+
 ## Time-window template substitution
 
 If a discovered query contains the literal token `{{TIMEWINDOW}}`, it is replaced with the raw `--time-window` value before submission. This lets queries opt into parameterization without requiring it:

--- a/plugins/investigate-appinsights-logs/commands/investigate-appinsights-logs.md
+++ b/plugins/investigate-appinsights-logs/commands/investigate-appinsights-logs.md
@@ -67,6 +67,8 @@ Run these in parallel:
    ```
    Parse the JSON array. If empty, tell the user no `.kql` files or ` ```kql ` fenced blocks were found and stop — the skill has nothing to run.
 
+   Entries that carry a `"skipped": "<reason>"` field (set by `// @skill-skip` markers inside the query body — typically on analytical helpers with hardcoded `datetime(...)` literals) must **not** be executed against `az`. Keep them in the per-query findings table annotated as `[SKIPPED: <reason>]` so the user sees they were discovered and deliberately bypassed.
+
 2. **Health snapshot** (only if `healthUrl` is set): `curl -s --max-time 10 "<healthUrl>"` and keep the body for the final report. A non-200 response is not fatal; include the status code and body in the report.
 
 ## Step 5: Run queries against App Insights
@@ -81,7 +83,7 @@ Run the queries **in parallel** (batch them in a single tool-use block), each as
 
 ```bash
 az monitor app-insights query \
-  --apps "<APP_INSIGHTS_ID>" \
+  --app "<APP_INSIGHTS_ID>" \
   --analytics-query "$(cat <<'KQL_BODY_EOF'
 <substituted query body>
 KQL_BODY_EOF
@@ -92,16 +94,19 @@ KQL_BODY_EOF
 
 If any discovered query body itself contains a standalone line exactly matching `KQL_BODY_EOF`, pick a different unique terminator for that call so the heredoc doesn't close early.
 
-Collect each query's `tables[0].rows` plus its source title. If any single query fails, keep its error in the report but don't abort the others.
+Collect each query's full response (all `tables[*]`) plus its source title. If any single query fails, keep its error in the report but don't abort the others.
 
 ## Step 6: Extract server events for the timeline
 
 From the query results, build a `server` event list for the timeline. Each event needs `utc` (ISO 8601), `kind` (a short category label), and `message` (one-line summary).
 
-Heuristics:
+**Iterate every table in the response** — `tables[*]`, not just `tables[0]`. Multi-statement KQL bodies (statements separated by blank lines) return one table per statement, each with its own `columns` schema. Apply the per-row heuristics below to every table independently, then merge all extracted events into the single `server` list.
+
+Per-table heuristics:
 - If a row has a `timestamp` (or `TimeGenerated`) column, that's `utc`. App Insights emits sub-second precision (4-7 fractional digits); `build_timeline.py` normalizes this, so pass timestamps through as-is.
 - If a row has `name`, `itemType`, `customDimensions.EventName`, `severityLevel`, `resultCode`, `type`, or similar, use it as `kind`. **Do not alias a KQL column to the name `kind` via `project` — `kind` is a reserved word in KQL and produces a `SyntaxError` at parse time.** Project to a different name (e.g., `project severity=severityLevel`) and map it to `kind` in the handler's Python reshape step.
 - For `message`, join the remaining salient columns into a single compact string.
+- If a table has no timestamp-like column (e.g., it's a `summarize`/`print` result), skip it — nothing to contribute to a time-based timeline.
 
 Cap at ~200 events per query to avoid flooding. If a query returns more, sample evenly across the window and note the sampling in the report.
 

--- a/plugins/investigate-appinsights-logs/scripts/discover_queries.py
+++ b/plugins/investigate-appinsights-logs/scripts/discover_queries.py
@@ -25,10 +25,18 @@ by name — at every depth — so nested `node_modules` are also dropped.
 
 Glob matching uses `fnmatch.fnmatchcase` (case-sensitive, deterministic across
 OSes). `*` matches any character including `/` — it is NOT shell-glob
-semantics. Use explicit patterns like `ops/polling.kql` or `**/*.kql` as
+semantics. Use explicit patterns like `ops/traces.kql` or `**/*.kql` as
 needed. ATX markdown headings only are recognized (setext `====`/`----` is
 not matched). Heading tracking is "sticky": a fenced block below a section
 header inherits the most recent heading, even across horizontal rules.
+
+Skip-marker convention: a query whose first non-blank line is a KQL comment
+containing `@skill-skip` (e.g. `// @skill-skip date-pinned helper`) is
+emitted with a `"skipped": "<reason>"` field and `"content": ""`. The
+handler is expected to surface these in the per-query findings table as
+`[SKIPPED: <reason>]` without executing the query against the Azure CLI.
+Useful for analytical helpers with hardcoded `datetime(...)` literals that
+would otherwise produce meaningless single-row results.
 """
 from __future__ import annotations
 
@@ -48,6 +56,26 @@ DEFAULT_SKIP_DIRS = {
 
 FENCE_RE = re.compile(r"^(`{3,}|~{3,})\s*([A-Za-z0-9_+.-]*)\s*$")
 HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.*?)\s*#*\s*$")
+# Matches a KQL comment on the first non-blank line carrying the @skill-skip marker.
+# Examples:
+#   // @skill-skip
+#   // @skill-skip date-pinned helper, meant for manual copy-paste
+SKILL_SKIP_RE = re.compile(r"^\s*//\s*@skill-skip(?:\s+(.+?))?\s*$")
+
+
+def skill_skip_reason(content: str) -> str | None:
+    """If `content`'s first non-blank line is a `// @skill-skip [reason]`
+    marker, return the trimmed reason (or the literal string "author-marked"
+    if no reason was supplied). Returns None if the marker is absent.
+    """
+    for line in content.splitlines():
+        if not line.strip():
+            continue
+        m = SKILL_SKIP_RE.match(line)
+        if m:
+            return (m.group(1) or "").strip() or "author-marked"
+        return None
+    return None
 
 
 def iter_files(root: Path, includes: list[str], excludes: list[str]):
@@ -144,11 +172,16 @@ def main(argv: list[str]) -> int:
                 continue
             if not text.strip():
                 continue
-            results.append({
+            entry: dict = {
                 "source": rel,
                 "title": title_from_kql(text, rel),
                 "content": text.rstrip() + "\n",
-            })
+            }
+            skip_reason = skill_skip_reason(text)
+            if skip_reason is not None:
+                entry["skipped"] = skip_reason
+                entry["content"] = ""
+            results.append(entry)
         elif suffix in {".md", ".markdown"}:
             try:
                 text = path.read_text(encoding="utf-8", errors="replace")
@@ -158,11 +191,16 @@ def main(argv: list[str]) -> int:
             for heading, content, idx in extract_kql_from_markdown(text):
                 if not content.strip():
                     continue
-                results.append({
+                entry = {
                     "source": f"{rel}#{idx}",
                     "title": heading or f"{rel} (block {idx})",
                     "content": content.rstrip() + "\n",
-                })
+                }
+                skip_reason = skill_skip_reason(content)
+                if skip_reason is not None:
+                    entry["skipped"] = skip_reason
+                    entry["content"] = ""
+                results.append(entry)
 
     json.dump(results, sys.stdout, indent=2)
     sys.stdout.write("\n")

--- a/plugins/investigate-appinsights-logs/scripts/test_discover_queries.sh
+++ b/plugins/investigate-appinsights-logs/scripts/test_discover_queries.sh
@@ -298,4 +298,84 @@ assert sources == ["keep.kql"], f"expected only keep.kql, got {sources}"
 PY
 pass "skip-dirs (.git, node_modules, __pycache__) pruned"
 
+# 15. `// @skill-skip` marker with a reason: emitted with skipped + empty content.
+case_dir="$(fresh_case_dir)"
+cat > "$case_dir/helper.kql" <<'KQL'
+// @skill-skip date-pinned analytical helper
+let cycleTime = datetime(2026-04-10T23:00:15Z);
+traces | where timestamp > cycleTime | take 5
+KQL
+out="$(python3 "$SUT" --cwd "$case_dir")"
+python3 - "$out" <<'PY' || fail "@skill-skip with reason failed: $out"
+import sys, json
+data = json.loads(sys.argv[1])
+assert len(data) == 1, f"expected 1 entry, got {data}"
+e = data[0]
+assert e["source"] == "helper.kql", e
+assert e.get("skipped") == "date-pinned analytical helper", e
+assert e["content"] == "", f"expected empty content on skipped entry, got {e['content']!r}"
+PY
+pass "@skill-skip marker with reason is honored"
+
+# 16. `// @skill-skip` with no reason falls back to 'author-marked'.
+case_dir="$(fresh_case_dir)"
+cat > "$case_dir/noreason.kql" <<'KQL'
+// @skill-skip
+traces | take 1
+KQL
+out="$(python3 "$SUT" --cwd "$case_dir")"
+python3 - "$out" <<'PY' || fail "@skill-skip no-reason failed: $out"
+import sys, json
+data = json.loads(sys.argv[1])
+assert len(data) == 1, f"expected 1 entry, got {data}"
+assert data[0].get("skipped") == "author-marked", data[0]
+PY
+pass "@skill-skip without reason falls back to 'author-marked'"
+
+# 17. `// @skill-skip` inside a markdown fenced block marks only that block as skipped.
+case_dir="$(fresh_case_dir)"
+cat > "$case_dir/ops.md" <<'MD'
+## Active
+```kql
+traces | take 1
+```
+
+## Helper
+```kql
+// @skill-skip hardcoded date
+let t = datetime(2026-04-10T00:00:00Z);
+traces | where timestamp > t
+```
+MD
+out="$(python3 "$SUT" --cwd "$case_dir")"
+python3 - "$out" <<'PY' || fail "@skill-skip in markdown fence failed: $out"
+import sys, json
+data = json.loads(sys.argv[1])
+assert len(data) == 2, f"expected 2 entries, got {data}"
+by_title = {e["title"]: e for e in data}
+assert "skipped" not in by_title["Active"], by_title["Active"]
+assert by_title["Helper"].get("skipped") == "hardcoded date", by_title["Helper"]
+assert by_title["Helper"]["content"] == "", by_title["Helper"]
+PY
+pass "@skill-skip in markdown fence marks only that block"
+
+# 18. `// @skill-skip` must be on the first non-blank line to count — a marker
+#     buried mid-query is NOT treated as a skip.
+case_dir="$(fresh_case_dir)"
+cat > "$case_dir/buried.kql" <<'KQL'
+// Real query
+traces
+// @skill-skip this is a middle-of-query comment, not a skip marker
+| take 5
+KQL
+out="$(python3 "$SUT" --cwd "$case_dir")"
+python3 - "$out" <<'PY' || fail "@skill-skip buried-line failed: $out"
+import sys, json
+data = json.loads(sys.argv[1])
+assert len(data) == 1, f"expected 1 entry, got {data}"
+assert "skipped" not in data[0], f"marker should only be honored on first non-blank line, got {data[0]}"
+assert "traces" in data[0]["content"], data[0]
+PY
+pass "@skill-skip only on first non-blank line counts as a skip marker"
+
 echo "all smoke tests passed"


### PR DESCRIPTION
## Summary
Three small fixes surfaced by the first production run of `/investigate-appinsights-logs` during an AvalancheAlert release-window incident.

1. **Revert `--apps` → `--app`** in Step 5 of the command markdown. The actual Azure CLI only accepts the singular flag; production parallel-batch of 6 queries failed with JSON-decode errors when `az` rejected `--apps`. The previous review flip was a misread of `az monitor app-insights query --help` — the example in that help output literally uses `--app`, so that's authoritative.
2. **`// @skill-skip` convention** for analytical-helper queries. Some `.kql` files and ` ```kql ` fenced blocks in a consumer repo have hardcoded `datetime(...)` literals or `let` bindings with specific times — meant for manual copy-paste, not live execution. `discover_queries.py` now recognizes `// @skill-skip [reason]` on the first non-blank line of a query body, emits the entry with a `"skipped": "<reason>"` field + empty content, and the command markdown instructs the handler to surface these as `[SKIPPED: <reason>]` in the per-query findings table without hitting `az`. The first-line rule (not mid-query) prevents accidental matches from ordinary comments.
3. **Iterate `tables[*]` in Step 6**, not just `tables[0]`. Multi-statement KQL bodies (statements separated by blank lines) return one table per statement with its own schema; previously sub-queries 2..N silently dropped out of the timeline. Also teaches the handler to skip tables with no timestamp-like column (e.g. a `summarize`/`print` tail that can't contribute to a time-based view).

## Design note on #119 fix-option selection (item 2)
Issue #119 listed three fix options for the analytical-helper problem. Picked the `// @skill-skip` comment convention because it's explicit, author-controlled, and can't produce false positives (the auto-detect `datetime(...)` option would mis-skip legitimate queries that happen to reference a date-literal cutoff).

## Files
- `plugins/investigate-appinsights-logs/commands/investigate-appinsights-logs.md` — Step 5 `--app` revert, Step 6 multi-table iteration, Step 4 `skipped`-field honored.
- `plugins/investigate-appinsights-logs/scripts/discover_queries.py` — `SKILL_SKIP_RE` + `skill_skip_reason()` helper; entries carrying the marker emitted with `"skipped"` field and empty `"content"`. Docstring documents the convention.
- `plugins/investigate-appinsights-logs/README.md` — new "Skipping analytical-helper queries" section with example.
- `plugins/investigate-appinsights-logs/scripts/test_discover_queries.sh` — 4 new test cases.

## Test plan
- [x] `@skill-skip` with free-form reason → emitted with matching `"skipped"` field
- [x] `@skill-skip` with no reason → falls back to `"author-marked"`
- [x] `@skill-skip` inside a markdown fenced block → marks only that block, not siblings
- [x] `@skill-skip` on a non-first line → NOT treated as a skip marker
- [x] All three test suites pass end-to-end (62 assertions total)
- [ ] End-to-end run against real App Insights with a known `// @skill-skip`-tagged helper in a consumer repo — deferred to next real incident use (same pattern as the parent PR's live-test step)

Closes #119