### PR TITLE
Add PR Size and Splitting guidance to team standards (#99)

### DIFF
--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -404,6 +404,31 @@ When asked to push a branch or create a pull request, remind the user to run `/d
 
 When an issue defines phased work (Phase 1, Phase 2, Phase 3), ship each phase as a separate PR — even when the phases feel small. Interaction bugs between phases (e.g., a new tri-state return value meeting existing binary assumptions in callers) only surface when the phases are integrated. Separate PRs catch these incrementally during review instead of requiring multiple fix-up commits after the fact.
 
+## PR Size and Splitting
+
+Large PRs are harder to review thoroughly, harder to revert safely, and harder to fit in a reviewer's working memory. Before opening a PR, check whether it can be split.
+
+**Split the work when:**
+- **One story covers multiple independent features.** Split the story first, then ship one PR per feature. A story like "rebuild these four back office apps" is four PRs, not one.
+- **A feature requires new shared infrastructure.** Land the infrastructure PR first (externalized config, new base classes, shared utilities, framework patterns), wait for it to merge, then rebase the feature PR on top. The feature PR should not introduce infra that future features will also consume.
+- **A PR mixes refactoring with new functionality.** Renames, reorganizations, and "while I was in there" cleanups go in their own PR. Mixing them with feature work obscures both.
+- **A PR touches multiple unrelated UI surfaces.** Expanding an existing feature tile (e.g., owner profile) and adding a new standalone dashboard are separate units of work.
+
+**Size guideline:**
+Aim for PRs under ~800 lines of functional change AND under ~20 files touched (excluding generated code, test fixtures, and one-type-per-file boilerplate that inflates line count without adding cognitive load). Exceeding either signal warrants a scope re-examination. PRs that must exceed either limit should include a one-paragraph justification in the description explaining why the work could not be split — and should still try. `/deep-review` can surface size-based concerns as part of its pass if you want an executable check.
+
+**Signs a PR is too large:**
+- Touches multiple unrelated features or UI surfaces
+- Contains both refactoring and new functionality
+- Introduces shared infrastructure that the current feature does not strictly require
+- Takes more than ~45 minutes for a reviewer to work through
+- Has commits with mismatched scope (e.g., "add feature X" alongside "refactor shared utility Y")
+
+**Before opening a PR, run this check:**
+1. List every commit on the branch. Do they all serve the same story?
+2. Are there commits that could have merged to `main` a week ago without the rest? Those should have been separate PRs.
+3. Does the PR description need multiple "Also, this change..." paragraphs? That's a sign of scope creep.
+
 <!-- Keep in sync with plugins/deep-review/commands/deep-review.md preamble -->
 ## Code Review Standards
 

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -408,25 +408,29 @@ When an issue defines phased work (Phase 1, Phase 2, Phase 3), ship each phase a
 
 Large PRs are harder to review thoroughly, harder to revert safely, and harder to fit in a reviewer's working memory. Before opening a PR, check whether it can be split.
 
-**Split the work when:**
+### Split the work when
+
 - **One story covers multiple independent features.** Split the story first, then ship one PR per feature. A story like "rebuild these four back office apps" is four PRs, not one.
 - **A feature requires new shared infrastructure.** Land the infrastructure PR first (externalized config, new base classes, shared utilities, framework patterns), wait for it to merge, then rebase the feature PR on top. The feature PR should not introduce infra that future features will also consume.
 - **A PR mixes refactoring with new functionality.** Renames, reorganizations, and "while I was in there" cleanups go in their own PR. Mixing them with feature work obscures both.
 - **A PR touches multiple unrelated UI surfaces.** Expanding an existing feature tile (e.g., owner profile) and adding a new standalone dashboard are separate units of work.
 
-**Size guideline:**
-Aim for PRs under ~800 lines of functional change AND under ~20 files touched (excluding generated code, test fixtures, and one-type-per-file boilerplate that inflates line count without adding cognitive load). Exceeding either signal warrants a scope re-examination. PRs that must exceed either limit should include a one-paragraph justification in the description explaining why the work could not be split — and should still try. `/deep-review` can surface size-based concerns as part of its pass if you want an executable check.
+### Size guideline
 
-**Signs a PR is too large:**
+Aim for PRs under ~800 lines of functional change AND under ~20 files touched (excluding generated code, test fixtures, and one-type-per-file boilerplate that inflates line count without adding cognitive load). Exceeding either signal warrants a scope re-examination. PRs that must exceed either limit should include a one-paragraph justification in the description explaining why the work could not be split — and should still try. You can ask `/deep-review` to weigh in on scope alongside its other checks.
+
+### Signs a PR is too large
+
 - Touches multiple unrelated features or UI surfaces
 - Contains both refactoring and new functionality
 - Introduces shared infrastructure that the current feature does not strictly require
-- Takes more than ~45 minutes for a reviewer to work through
+- Takes ~45 minutes or more for a reviewer to work through
 - Has commits with mismatched scope (e.g., "add feature X" alongside "refactor shared utility Y")
 
-**Before opening a PR, run this check:**
+### Before opening a PR, run this check
+
 1. List every commit on the branch. Do they all serve the same story?
-2. Are there commits that could have merged to `main` a week ago without the rest? Those should have been separate PRs.
+2. Are there commits that could have merged to `main` earlier in the branch's life without the rest? Those should have been separate PRs.
 3. Does the PR description need multiple "Also, this change..." paragraphs? That's a sign of scope creep.
 
 <!-- Keep in sync with plugins/deep-review/commands/deep-review.md preamble -->

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -408,12 +408,12 @@ When an issue defines phased work (Phase 1, Phase 2, Phase 3), ship each phase a
 
 Large PRs are harder to review thoroughly, harder to revert safely, and harder to fit in a reviewer's working memory. Before opening a PR, check whether it can be split.
 
-### Split the work when
+### When to split the work
 
 - **One story covers multiple independent features.** Split the story first, then ship one PR per feature. A story like "rebuild these four back office apps" is four PRs, not one.
-- **A feature requires new shared infrastructure.** Land the infrastructure PR first (externalized config, new base classes, shared utilities, framework patterns), wait for it to merge, then rebase the feature PR on top. The feature PR should not introduce infra that future features will also consume.
+- **A feature requires new shared infrastructure.** Land the infrastructure PR first (externalized config, new base classes, shared utilities, framework patterns), wait for it to merge, then bring the feature branch up to date with `main`. The feature PR should not introduce infra that future features will also consume.
 - **A PR mixes refactoring with new functionality.** Renames, reorganizations, and "while I was in there" cleanups go in their own PR. Mixing them with feature work obscures both.
-- **A PR touches multiple unrelated UI surfaces.** Expanding an existing feature tile (e.g., owner profile) and adding a new standalone dashboard are separate units of work.
+- **A PR touches multiple unrelated UI surfaces.** Expanding an existing feature tile (e.g., a profile panel) and adding a new standalone dashboard are separate units of work.
 
 ### Size guideline
 


### PR DESCRIPTION
## Summary
Adds a new **PR Size and Splitting** section to `standards/CLAUDE.md`, placed between **Phased Work** and **Code Review Standards**. Matches the draft in issue #99 with a few refinements agreed during design review.

## Refinements from the issue draft
- **Size threshold: ~800 lines AND ~20 files.** The issue asked whether a file count cap should join the 800-line limit. Added as a co-signal — catches rename-heavy PRs that stay under 800 lines but spread across many files. Either signal triggers scope re-examination.
- **Soft enforcement with mandatory justification on exceedance.** Hard rules can't distinguish legitimate coordinated changes (schema migrations, framework upgrades) from over-scoped PRs, and invite workarounds. The justification paragraph gives reviewers something concrete to push back on.
- **Exclusion list reordered:** `generated code, test fixtures, one-type-per-file boilerplate` (most universal exclusion first).
- **Brief cross-reference to `/deep-review`** as an optional executable check, without requiring any deep-review code change in this PR.

## Deferred to follow-up issues
- **`/improve-stories` extension** to flag multi-feature user stories at grooming time (the most upstream place to prevent the over-scoped PR that motivated #99) → will be tracked in a follow-up issue to keep this standards PR focused, per its own guidance.
- **`/deep-review` hard size-flagging** → the issue's own "Next steps" marked this as optional; leaving the soft cross-reference as sufficient for now.

## Downstream action
Developers should re-run `./setup-env.sh` (or `./setup-env.ps1` on Windows) to sync the updated `standards/CLAUDE.md` into their `~/.claude/CLAUDE.md`. The sync is additive and won't disturb personal overrides.

## Test plan
- [x] Section placement verified: sits between `## Phased Work` (line 403) and `## Code Review Standards` (line 433) as the issue requested
- [x] Section content matches the issue's draft with the four agreed refinements
- [x] No changes to any synced-from file outside `standards/CLAUDE.md`
- [ ] Manual: re-run sync script on a clean developer workstation to confirm the new section lands in `~/.claude/CLAUDE.md` without conflict

Closes #99