### PR TITLE
Extend /improve-stories to detect multi-feature stories (#122)

### DIFF
--- a/plugins/improve-stories/README.md
+++ b/plugins/improve-stories/README.md
@@ -34,12 +34,12 @@ Examples:
 
 When a story names several independently-shippable features (e.g., "Add day-use parking, parking restrictions, and parking override"), the skill proposes splitting it into child stories before any implementation work begins. Signals include "and"/comma-linked distinct feature nouns in the title, acceptance criteria that cluster into independent groups, and multiple distinct user-facing deliverables. Rationale and thresholds live in `standards/CLAUDE.md` → **PR Size and Splitting** (the team standard this extension enforces upstream).
 
-On approval, the skill creates the children (GitHub: `gh issue create` + `addBlockedBy` linking; ADO: `wit_create_work_item` + Parent/Child links), annotates the parent with pointers to the children, and optionally queues the new children through the same improvement flow in the current session.
+On approval, the skill creates the children (GitHub: `gh issue create` + `addBlockedBy` linking; ADO: `wit_add_child_work_items` for atomic create-and-parent-link), annotates the parent with pointers to the children, and optionally queues the new children through the same improvement flow in the current session.
 
 ## Large Batches
 
 When a batch contains many items, the skill filters and chunks automatically:
 
 - Items unrelated to the current repository are skipped
-- Only items needing improvement are processed (well-documented items are skipped)
+- Only items needing improvement or splitting are processed (well-documented items are skipped)
 - Remaining items are processed in chunks of 5, with a progress update after each chunk

--- a/plugins/improve-stories/README.md
+++ b/plugins/improve-stories/README.md
@@ -24,10 +24,17 @@ Examples:
 1. Detects the source (GitHub Issues or Azure DevOps) based on the argument
 2. Fetches items with a lightweight query, then full details only for candidates
 3. Filters to items relevant to the current repository
-4. Triages each item and asks you to confirm before making changes
-5. Researches the codebase for each poorly-scoped item
-6. Writes structured descriptions with problem statements, root causes, proposed fixes, and acceptance criteria
-7. Updates the items — does not change title, state, assignment, labels, or points
+4. Triages each item: **well-documented** (skip), **needs improvement** (rewrite), or **multi-feature** (propose a split into child stories)
+5. For multi-feature items, drafts a split plan and asks you to confirm before creating any child items. Never auto-splits.
+6. Researches the codebase for each item that needs improvement
+7. Writes structured descriptions with problem statements, root causes, proposed fixes, and acceptance criteria
+8. Updates the items — does not change title, state, assignment, labels, or points
+
+## Multi-feature story detection
+
+When a story names several independently-shippable features (e.g., "Add day-use parking, parking restrictions, and parking override"), the skill proposes splitting it into child stories before any implementation work begins. Signals include "and"/comma-linked distinct feature nouns in the title, acceptance criteria that cluster into independent groups, and multiple distinct user-facing deliverables. Rationale and thresholds live in `standards/CLAUDE.md` → **PR Size and Splitting** (the team standard this extension enforces upstream).
+
+On approval, the skill creates the children (GitHub: `gh issue create` + `addBlockedBy` linking; ADO: `wit_create_work_item` + Parent/Child links), annotates the parent with pointers to the children, and optionally queues the new children through the same improvement flow in the current session.
 
 ## Large Batches
 

--- a/plugins/improve-stories/commands/improve-stories.md
+++ b/plugins/improve-stories/commands/improve-stories.md
@@ -1,7 +1,7 @@
 ---
 name: improve-stories
 description: Review user stories and GitHub issues for completeness, research the codebase to fill gaps, and update each with structured documentation
-allowed-tools: Bash, Read, Grep, Glob, Agent, AskUserQuestion, mcp__azure-devops__core_list_project_teams, mcp__azure-devops__wit_get_work_items_for_iteration, mcp__azure-devops__wit_get_work_item, mcp__azure-devops__wit_update_work_item, mcp__azure-devops__wit_add_work_item_comment, mcp__azure-devops__wit_my_work_items, mcp__azure-devops__wit_list_backlogs, mcp__azure-devops__wit_list_backlog_work_items, mcp__azure-devops__wit_get_work_items_batch_by_ids, mcp__azure-devops__wit_work_items_link, mcp__azure-devops__wit_create_work_item
+allowed-tools: Bash, Read, Grep, Glob, Agent, AskUserQuestion, mcp__azure-devops__core_list_project_teams, mcp__azure-devops__wit_get_work_items_for_iteration, mcp__azure-devops__wit_get_work_item, mcp__azure-devops__wit_update_work_item, mcp__azure-devops__wit_add_work_item_comment, mcp__azure-devops__wit_my_work_items, mcp__azure-devops__wit_list_backlogs, mcp__azure-devops__wit_list_backlog_work_items, mcp__azure-devops__wit_get_work_items_batch_by_ids, mcp__azure-devops__wit_work_items_link, mcp__azure-devops__wit_add_child_work_items
 user-input: optional
 argument-hint: "[iteration-path, work-item-ids, or #issue-number]"
 model: opus
@@ -124,7 +124,7 @@ Present the triage summary to the user:
 - Ask the user to confirm before proceeding
 - If the user declines, asks to skip specific items, or wants to add items that were filtered out, adjust the selection accordingly and re-present the updated plan
 
-## Step 3d: Execute approved splits
+### 3d: Execute approved splits
 
 For each item the user confirmed as multi-feature, propose a concrete split **before creating anything**:
 
@@ -132,19 +132,20 @@ For each item the user confirmed as multi-feature, propose a concrete split **be
 2. **Present the split plan** to the user with proposed child titles + summaries, how the parent's content is being distributed, and what happens to the parent (left open as a tracking item with pointers to children, or closed with pointers — user's call).
 3. **On approval, create the children and link them.** Do not create anything before approval. If the user rejects or modifies, re-present the revised plan before proceeding.
 
+**Partial-failure handling:** If one or more child creations fail partway through, do **not** roll back the children that were already created. Report which children were created (with IDs/numbers), which failed (with the error), and ask the user how to proceed before continuing — retry the failed child, skip it, or stop and clean up manually. Same convention as Step 4f's "report and continue" pattern.
+
 **GitHub:**
-- Create each child with `gh issue create --title "<title>" --body "<summary + relevant content from parent>" --label <parent-labels>`. Preserve the parent's labels on each child.
-- Link the parent as **blocked by** each child via the `addBlockedBy` GraphQL mutation (see `standards/CLAUDE.md` → **GitHub Issue Relationships**). The parent becomes a tracking issue that only auto-closes when all children do.
-- Append to the parent description: `Split into #<A>, #<B>, #<C>. This parent closes when all children are complete.`
+- Create each child with `gh issue create --title "<title>" --body "<summary + relevant content from parent>" --label <parent-labels>`. Copy only labels that describe the work itself (component, priority, area). Skip umbrella labels like `epic`, `tracking`, or `parent-issue` if present on the parent.
+- Link the parent as **blocked by** each child via the `addBlockedBy` GraphQL mutation (see `standards/CLAUDE.md` → **GitHub Issue Relationships**). This makes the parent a tracking issue surfaced in GitHub's "Linked issues" UI; it does **not** auto-close the parent when children resolve — the user (or a separate workflow) closes the parent manually once all children are complete.
+- Append to the parent description: `Split into #<A>, #<B>, #<C>. Close manually once all children are complete.`
 - Audit trail: `gh issue comment <parent> --body "Split into <N> child issues per multi-feature detection. Children: #<A>, #<B>, #<C>."`
 
 **ADO:**
-- Create each child with `mcp__azure-devops__wit_create_work_item`, using the same work item type as the parent (typically User Story or Product Backlog Item) and preserving the parent's area path and tags.
-- Link parent and each child as **Parent / Child** with `wit_work_items_link` (set type `parent` on the child pointing to the parent ID). ADO errors on duplicate links — check existing links on the child before creating.
+- Create all children for one parent in a single call to `mcp__azure-devops__wit_add_child_work_items` — the tool creates and parent-links each child atomically. Pass `parentId`, `workItemType` (default to the parent's `System.WorkItemType`, typically User Story or Product Backlog Item — ask the user if the parent is an Epic or Feature and the children should be a different type), and an `items` array with `{title, description, format, areaPath, iterationPath}` for each child. Default `format` to whatever was detected in Step 4c (HTML vs Markdown); preserve the parent's `areaPath` and `iterationPath` on each child unless the user overrides.
 - Append to the parent description: `Split into <child IDs>. This parent tracks the aggregate effort; implementation happens on the children.`
 - Audit trail: `wit_add_work_item_comment` on the parent explaining the split.
 
-**After split:** Ask the user whether to queue the newly-created children through Step 4 (research + improve descriptions) in the current session. If yes, add them to the in-flight list with their classification recomputed (well-documented vs needs improvement) and proceed. If no, stop here for those items — the user can re-run `/improve-stories` on the children later.
+**After split:** Ask the user whether to queue the newly-created children through Step 4 (research + improve descriptions) in the current session. If yes, add them to the items-to-improve queue and proceed — newly-created children will almost always need research and full descriptions, so they pass through Step 4 normally. If no, stop here for those items — the user can re-run `/improve-stories` on the children later.
 
 ## Step 4: Research and Update (chunked)
 

--- a/plugins/improve-stories/commands/improve-stories.md
+++ b/plugins/improve-stories/commands/improve-stories.md
@@ -1,7 +1,7 @@
 ---
 name: improve-stories
 description: Review user stories and GitHub issues for completeness, research the codebase to fill gaps, and update each with structured documentation
-allowed-tools: Bash, Read, Grep, Glob, Agent, AskUserQuestion, mcp__azure-devops__core_list_project_teams, mcp__azure-devops__wit_get_work_items_for_iteration, mcp__azure-devops__wit_get_work_item, mcp__azure-devops__wit_update_work_item, mcp__azure-devops__wit_add_work_item_comment, mcp__azure-devops__wit_my_work_items, mcp__azure-devops__wit_list_backlogs, mcp__azure-devops__wit_list_backlog_work_items, mcp__azure-devops__wit_get_work_items_batch_by_ids, mcp__azure-devops__wit_work_items_link
+allowed-tools: Bash, Read, Grep, Glob, Agent, AskUserQuestion, mcp__azure-devops__core_list_project_teams, mcp__azure-devops__wit_get_work_items_for_iteration, mcp__azure-devops__wit_get_work_item, mcp__azure-devops__wit_update_work_item, mcp__azure-devops__wit_add_work_item_comment, mcp__azure-devops__wit_my_work_items, mcp__azure-devops__wit_list_backlogs, mcp__azure-devops__wit_list_backlog_work_items, mcp__azure-devops__wit_get_work_items_batch_by_ids, mcp__azure-devops__wit_work_items_link, mcp__azure-devops__wit_create_work_item
 user-input: optional
 argument-hint: "[iteration-path, work-item-ids, or #issue-number]"
 model: opus
@@ -104,15 +104,47 @@ Using the fields already fetched, skip items without needing their full descript
 - Missing steps to reproduce (for bugs)
 - No mention of affected files or components
 
+**Multi-feature** — flag if the item bundles multiple independently-shippable features. See `standards/CLAUDE.md` → **PR Size and Splitting** → "When to split the work" for the underlying rationale. Use **several signals together**, not any single one alone:
+
+- Title links distinct feature nouns via "and", commas, or a list ("X, Y, and Z"; "Feature A and Feature B")
+- Acceptance criteria cluster into independent groups under separate sub-headings — each group's criteria could pass or fail without the others
+- Scope mentions multiple distinct user-facing deliverables (separate pages, dashboards, workflows, APIs that users would reasonably treat as separate features)
+- Story size is at or above the team's threshold for "one story" (if points/hours are consistently scored)
+
+Use judgment: "update the settings panel and fix the breadcrumb bug" is a bugfix + small polish, not multi-feature. "Add day-use parking, parking restrictions, and parking override" clearly is. When an item is both multi-feature AND needs improvement, classify it as multi-feature — the split comes first, and the children get improved separately.
+
 **Detecting item type:** For ADO, use `System.WorkItemType`. For GitHub, infer from labels — issues labeled `bug` are bugs, others are features. If no labels exist, infer from the title and body content (error reports, "broken", "doesn't work" → bug; otherwise feature).
 
 Present the triage summary to the user:
-- How many items were fetched, how many were filtered as irrelevant, how many are well-documented, how many need improvement
+- How many items were fetched, how many were filtered as irrelevant, how many are well-documented, how many need improvement, how many appear multi-feature
 - List which items you plan to improve and why
+- List each multi-feature item separately with a note: `#<id> "<title>" — appears to bundle <N> features: <A>, <B>, <C>`. Ask the user to confirm, demote to "needs improvement", or demote to "well-documented".
 - List which items you're skipping and why
 - If more than 10 items need improvement, recommend processing in chunks and ask the user how many to tackle now
 - Ask the user to confirm before proceeding
 - If the user declines, asks to skip specific items, or wants to add items that were filtered out, adjust the selection accordingly and re-present the updated plan
+
+## Step 3d: Execute approved splits
+
+For each item the user confirmed as multi-feature, propose a concrete split **before creating anything**:
+
+1. **Draft each child.** For each feature the parent bundles: a concise title (one of the feature nouns the parent lists), a one-sentence summary, and a note on which parts of the parent's existing content (description, acceptance criteria, reference images) belong to that child. Images and attachments follow the feature they illustrate — if that can't be determined, mention them under the parent's post-split note.
+2. **Present the split plan** to the user with proposed child titles + summaries, how the parent's content is being distributed, and what happens to the parent (left open as a tracking item with pointers to children, or closed with pointers — user's call).
+3. **On approval, create the children and link them.** Do not create anything before approval. If the user rejects or modifies, re-present the revised plan before proceeding.
+
+**GitHub:**
+- Create each child with `gh issue create --title "<title>" --body "<summary + relevant content from parent>" --label <parent-labels>`. Preserve the parent's labels on each child.
+- Link the parent as **blocked by** each child via the `addBlockedBy` GraphQL mutation (see `standards/CLAUDE.md` → **GitHub Issue Relationships**). The parent becomes a tracking issue that only auto-closes when all children do.
+- Append to the parent description: `Split into #<A>, #<B>, #<C>. This parent closes when all children are complete.`
+- Audit trail: `gh issue comment <parent> --body "Split into <N> child issues per multi-feature detection. Children: #<A>, #<B>, #<C>."`
+
+**ADO:**
+- Create each child with `mcp__azure-devops__wit_create_work_item`, using the same work item type as the parent (typically User Story or Product Backlog Item) and preserving the parent's area path and tags.
+- Link parent and each child as **Parent / Child** with `wit_work_items_link` (set type `parent` on the child pointing to the parent ID). ADO errors on duplicate links — check existing links on the child before creating.
+- Append to the parent description: `Split into <child IDs>. This parent tracks the aggregate effort; implementation happens on the children.`
+- Audit trail: `wit_add_work_item_comment` on the parent explaining the split.
+
+**After split:** Ask the user whether to queue the newly-created children through Step 4 (research + improve descriptions) in the current session. If yes, add them to the in-flight list with their classification recomputed (well-documented vs needs improvement) and proceed. If no, stop here for those items — the user can re-run `/improve-stories` on the children later.
 
 ## Step 4: Research and Update (chunked)
 


### PR DESCRIPTION
## Summary
Closes the upstream-grooming gap flagged in #99: many over-scoped PRs start from over-scoped stories, and catching that at triage — before any code is written — is strictly higher-leverage than catching it during PR review.

The `/improve-stories` triage phase now has a third classification bucket, **Multi-feature**, alongside the existing "well-documented" (skip) and "needs improvement" (rewrite). When a story bundles several independently-shippable features, the skill proposes a concrete split, asks the user to confirm, and only then creates the child items + links. Never auto-splits.

## Changes
- **`plugins/improve-stories/commands/improve-stories.md`**
  - **Step 3c** gains the **Multi-feature** classification with the four detection signals (title pattern, independent acceptance-criteria groups, multiple deliverables, story size at threshold). Cross-references the new `standards/CLAUDE.md → PR Size and Splitting → "When to split the work"` section as the rationale source.
  - **Triage summary** now lists multi-feature candidates separately and asks the user to confirm, demote to "needs improvement", or demote to "well-documented".
  - **New Step 3d: Execute approved splits** — drafts child titles + summaries + content distribution, presents the plan, creates children only after approval. GitHub path uses `gh issue create` + `addBlockedBy` GraphQL linking; ADO path uses the newly-added `wit_create_work_item` tool + Parent/Child links. Parent is annotated with pointers; user decides whether to close it or leave it open as a tracking item. Optional follow-on: queue the new children through Step 4 (improve) in the same session.
  - `allowed-tools` adds `mcp__azure-devops__wit_create_work_item` — the only new capability the skill needs (GitHub uses the already-allowed `gh` via Bash).
- **`plugins/improve-stories/README.md`**
  - Triage step description updated to mention the three buckets.
  - New "Multi-feature story detection" section explains the behavior and links to the underlying team standard.

## Design choices

**Multiple signals required, not any single match.** "Update the settings panel and fix the breadcrumb bug" has "and" but is a small bugfix, not a multi-feature story. Detection uses LLM judgment weighing several signals together; the prose explicitly says "any one signal alone is rarely sufficient".

**Propose-confirm-act, never auto-split.** Mirrors the existing Step 4b dependency-analysis pattern. The user reviews proposed child titles, content distribution, and parent disposition before any creation happens.

**Multi-feature beats needs-improvement when both apply.** Splitting first, then improving children separately, is strictly better than rewriting an over-scoped parent description.

## Test plan
- [x] Markdown structure renders cleanly (Step 3d sits between the triage summary and Step 4; numbering is consistent)
- [x] No tool drift: `wit_create_work_item` is the only new entry in `allowed-tools`; `gh issue create` works through pre-existing Bash
- [x] Cross-references to `standards/CLAUDE.md` use the actual section anchors landed in PR #121
- [ ] **Live-test**: deferred to next real `/improve-stories` invocation against an actual multi-feature story (per the team's "live-test before declaring done" pattern). The skill is invoked from a consumer repo so the test happens during use, not in this PR.

Closes #122