### PR TITLE
Add /start-work skill (#124)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -111,6 +111,14 @@
       "source": "./plugins/investigate-appinsights-logs",
       "category": "development",
       "strict": false
+    },
+    {
+      "name": "start-work",
+      "description": "Start a new unit of work from a GitHub issue or ADO work item — runs Git Hygiene, creates branches/<id>-<slug> in a worktree by default, self-assigns/transitions state, runs codebase research, and hands off a draft plan",
+      "author": { "name": "Tim Zander" },
+      "source": "./plugins/start-work",
+      "category": "productivity",
+      "strict": false
     }
   ]
 }

--- a/plugins/start-work/.claude-plugin/plugin.json
+++ b/plugins/start-work/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "start-work",
+  "description": "Start a new unit of work from a GitHub issue or ADO work item — runs Git Hygiene, creates branches/<id>-<slug> in a worktree by default, self-assigns/transitions state, then runs codebase research and hands off a draft plan",
+  "author": {
+    "name": "Tim Zander"
+  }
+}

--- a/plugins/start-work/README.md
+++ b/plugins/start-work/README.md
@@ -1,0 +1,37 @@
+# start-work
+
+Bookend to `craft-pr`. Encodes the **Git Hygiene Before New Work**, **Branch Naming and PR Linking**, and **Mark Work Items Active** procedures from `standards/CLAUDE.md` so every developer lands on the same starting line when picking up a card.
+
+## Usage
+
+```
+/start-work 7212         # ADO work item by ID
+/start-work #29          # GitHub issue by number
+/start-work              # detect next priority from "my work items" / assigned issues
+```
+
+Optional flags:
+
+- `--base <branch>` — base the new branch on a non-`main` branch (e.g., a long-lived feature branch). Default: `main`.
+- `--no-worktree` — skip worktree creation; create the branch in the current checkout instead. Default: a worktree is created at `.claude/worktrees/<id>-<slug>` for parallel multi-task isolation.
+
+## What it does
+
+1. **Detect source** — GitHub issue (`#NN`) or ADO work item (bare ID), same logic as `improve-stories`.
+2. **Fetch the card** — title, description, area path, current state, dependencies.
+3. **Run Git Hygiene** — verify clean tree, fetch the base branch, fast-forward.
+4. **Create the branch** — `branches/<id>-<slug>` from clean base, slug derived from the title (kebab-case, ≤ 50 chars).
+5. **Worktree by default** — branch lives in `.claude/worktrees/<id>-<slug>` for isolation. `--no-worktree` opts out.
+6. **Mark work item active** — `gh issue edit --add-assignee @me` for GitHub; ADO transitions to `Active` and self-assigns.
+7. **Codebase research** — Explore subagent scoped to keywords from the card returns a short punch list of touched files.
+8. **Draft plan handoff** — present the card + research + suggested approach for your review before any implementation begins.
+
+## Why a worktree by default
+
+Worktrees keep new work isolated from the main checkout: uncommitted changes and untracked files in the parent stay put, switching contexts between tasks is one `cd` away, and there's no need to stash or juggle. The team standard documents `branches/<id>-<slug>` naming; the worktree just adds isolation on top of that — same branch name either way.
+
+## Requirements
+
+- `git` 2.20+ (worktree support)
+- **GitHub:** `gh` CLI authenticated for the target repo
+- **ADO:** `az` CLI with the `azure-devops` extension and the Azure DevOps MCP server, both already required by `improve-stories`

--- a/plugins/start-work/README.md
+++ b/plugins/start-work/README.md
@@ -19,7 +19,7 @@ Optional flags:
 
 1. **Detect source** — GitHub issue (`#NN`) or ADO work item (bare ID), same logic as `improve-stories`.
 2. **Fetch the card** — title, description, area path, current state, dependencies.
-3. **Run Git Hygiene** — verify clean tree, fetch the base branch, fast-forward.
+3. **Run Git Hygiene** — verify clean tree, fetch `origin/<base>`. The new branch is rooted directly at the latest `origin/<base>` tip, so no fast-forward of local `<base>` is needed.
 4. **Create the branch** — `branches/<id>-<slug>` from clean base, slug derived from the title (kebab-case, ≤ 50 chars).
 5. **Worktree by default** — branch lives in `.claude/worktrees/<id>-<slug>` for isolation. `--no-worktree` opts out.
 6. **Mark work item active** — `gh issue edit --add-assignee @me` for GitHub; ADO transitions to `Active` and self-assigns.

--- a/plugins/start-work/commands/start-work.md
+++ b/plugins/start-work/commands/start-work.md
@@ -1,0 +1,131 @@
+---
+name: start-work
+description: Start a new unit of work from a GitHub issue or ADO work item — runs Git Hygiene, creates branches/<id>-<slug> in a worktree by default, self-assigns/transitions state, runs codebase research, and hands off a draft plan
+argument-hint: "[<id> | #<number>] [--base <branch>] [--no-worktree]"
+allowed-tools: Bash, Read, Grep, Glob, Agent, AskUserQuestion, EnterWorktree, mcp__azure-devops__core_list_project_teams, mcp__azure-devops__wit_my_work_items, mcp__azure-devops__wit_get_work_item, mcp__azure-devops__wit_update_work_item, mcp__azure-devops__wit_add_work_item_comment
+user-input: optional
+model: opus
+---
+
+You are starting a new unit of work — picking up a card and lining up everything a developer needs before writing any code. Your deliverable is a **prepared workspace** (clean branch in a worktree, card marked active, codebase research summarized) plus a **draft plan** for the user to review before implementation begins. You do NOT begin implementation.
+
+This skill is the bookend to `craft-pr`: same dual-source GitHub-or-ADO pattern as `improve-stories`, encoding the **Git Hygiene Before New Work**, **Branch Naming and PR Linking**, and **Mark Work Items Active** procedures from `standards/CLAUDE.md` so every developer lands on the same starting line.
+
+## Step 0: Parse arguments
+
+Recognized inputs:
+- **Positional:** `7212` (bare numeric → ADO unless a GitHub remote exists, in which case ask), `#29` (always GitHub), or omitted (auto-detect next priority).
+- `--base <branch>` — base the new branch on a non-`main` branch (default: `main`). Use this when starting a child task off a long-lived feature branch.
+- `--no-worktree` — create the branch in the current checkout instead of a worktree (default: worktree at `.claude/worktrees/<id>-<slug>/`).
+
+If no positional argument is supplied, proceed to Step 1's auto-detect path.
+
+## Step 1: Detect source and fetch the card
+
+Detection logic (same as `improve-stories` Step 0):
+
+- **GitHub** if the argument starts with `#`, OR is bare numeric AND the repo has a GitHub remote (`gh repo view --json url 2>/dev/null` succeeds), OR the user explicitly says "issue".
+- **ADO** if the argument is bare numeric AND there's no GitHub remote, OR the user explicitly references an ADO concept (work item, area path, sprint).
+- **Ambiguous** (bare numeric with GitHub remote present): use AskUserQuestion — "Did you mean GitHub issue #<N> or ADO work item <N>?".
+
+### GitHub path
+
+- **Specific issue:** `gh issue view <number> --json number,title,state,labels,body,assignees` to fetch the card.
+- **Auto-detect:** `gh issue list --assignee @me --state open --json number,title,labels --limit 20`. If empty, also try `gh issue list --state open --label "ready" --json number,title --limit 20` (or whatever "ready for development" label the team uses; ask if unclear). If multiple results, present the list and ask the user which to start. Never auto-pick.
+
+### ADO path
+
+- **Specific work item:** `mcp__azure-devops__wit_get_work_item` for the ID; capture `System.Id`, `System.Title`, `System.State`, `System.WorkItemType`, `System.AreaPath`, `System.Tags`, `System.AssignedTo`, `System.Description`, `Microsoft.VSTS.Common.AcceptanceCriteria`.
+- **Auto-detect:** `mcp__azure-devops__wit_my_work_items` for items assigned to the user. Same multi-result handling as GitHub — present and ask.
+
+**State guard:** If the card is in `Active`, `In Progress`, `Resolved`, `Closed`, or `Done`, surface that to the user and ask for confirmation before proceeding. Picking up an in-progress card may step on someone else's work; resuming your own paused card is fine but should be intentional.
+
+## Step 2: Derive a kebab-case slug from the title
+
+Rules (matching the **Branch Naming and PR Linking** standard):
+- Lowercase letters, digits, single hyphens between words.
+- Strip punctuation: parentheses, brackets, slashes, colons, commas, periods, quotes.
+- Collapse whitespace and underscores to single hyphens.
+- Trim leading and trailing hyphens.
+- Truncate to ≤ 50 characters at a word boundary; never split a word mid-character.
+
+Examples:
+- "Add two-factor auth to login flow" → `add-two-factor-auth-to-login-flow`
+- "Bug: payment rounding (PR #123)" → `bug-payment-rounding-pr-123`
+- "Umbraco 17 — Day Use Parking Stand alone Features" → `umbraco-17-day-use-parking-stand-alone-features`
+
+If the title produces an empty slug (e.g., a non-Latin title with no obvious transliteration), use AskUserQuestion to ask the user for a slug.
+
+## Step 3: Locate the bundled script
+
+Use Glob with the pattern `**/start-work/**/start-work.sh` rooted at the user's home directory `~/.claude/plugins` (resolve `~` to an absolute path before calling Glob).
+
+If Glob returns multiple candidates, skip any whose version directory (the parent of `scripts/`) contains a `.orphaned_at` marker (check with Read). If zero candidates remain, tell the user the plugin may need reinstalling and stop. If multiple remain, use the first (Glob returns most-recently-modified first).
+
+## Step 4: Run Git Hygiene and create the branch
+
+```bash
+bash <resolved-script-path> --slug "<slug>" --id "<id>" [--base "<base>"] [--no-worktree]
+```
+
+Capture the last lines of stdout:
+- `BRANCH=branches/<id>-<slug>` (always present)
+- `WORKTREE_PATH=.claude/worktrees/<id>-<slug>` (present only in worktree mode)
+
+If the script exits non-zero, surface its stderr verbatim and stop. The script's failure modes are: dirty working tree (user must commit, stash, or discard), branch already exists locally (user must rename or delete the existing branch), worktree path already exists (likely a paused-and-resumed card — surface that), unreachable origin (network/auth issue), or `--base` doesn't exist on origin.
+
+Omit `--id` if the card has no numeric identifier (rare — typically a developer-initiated branch with no tracked work item). The script handles this: branch becomes `branches/<slug>` with no numeric prefix.
+
+## Step 5: Enter the worktree (worktree mode only)
+
+If `WORKTREE_PATH=` was emitted in Step 4, switch the session into the worktree using `EnterWorktree` with the `path` parameter set to the captured value. The session's working directory becomes the new worktree, and subsequent steps run there.
+
+Skip this step entirely in `--no-worktree` mode (the script already left the user on the new branch in the original checkout).
+
+## Step 6: Mark the work item active
+
+### GitHub
+```bash
+gh issue edit <number> --add-assignee @me
+```
+GitHub has no formal state to transition — assignment is the active signal.
+
+### ADO
+Use `mcp__azure-devops__wit_update_work_item` to:
+1. Set `System.State` to `Active`. Some teams use `In Progress` or another non-default state name — if the project's process template uses a non-`Active` next state, surface the choices and ask the user before guessing.
+2. Set `System.AssignedTo` to the current user (look up via `mcp__azure-devops__core_list_project_teams` with `mine=true` if the email isn't readily available, or use the user's `~/.claude/CLAUDE.md`-stored work email).
+
+If the work item is already `Active` and assigned to the current user, this step is a no-op — log it and continue.
+
+## Step 7: Codebase research
+
+Delegate to an `Explore` subagent (specialized agent for fast codebase exploration) so the full search transcript stays out of the main context. Pass the agent:
+- The card's title and description (verbatim — the agent uses these to seed its searches)
+- A concise prompt asking it to identify candidate files, components, services, models, or patterns related to the work, and to return a short punch list (under 200 words)
+
+Set thoroughness based on the card's apparent scope:
+- `quick` — trivially-scoped (typo fix, single-string change, one-bullet acceptance criteria)
+- `medium` — typical default
+- `very thorough` — only when the user explicitly requests deeper context, or when the card spans clearly distinct surfaces
+
+The agent's compact summary is what enters main context. Never the full search transcript.
+
+## Step 8: Draft the plan and hand off
+
+Present a single structured handoff message in this exact order:
+
+1. **Card** — `[<source> #<id>] <title>` plus a one-line summary of scope drawn from the description.
+2. **Workspace** — branch name, worktree path (or "in-place — `--no-worktree`"), base branch, and notable card metadata (state, assignee, tags, area path).
+3. **Codebase research** — the punch list returned by Step 7, verbatim.
+4. **Draft plan** — 3-7 numbered steps proposing the implementation approach, grounded in the research. Each step is one short sentence. Explicitly call out non-obvious assumptions or open questions ("assumes the validator runs before the cache write — confirm").
+5. **Suggested next action** — typically: "Review the plan, then run Plan mode (or proceed directly) to start implementation."
+
+Stop here. The deliverable is the prepared workspace + the draft plan. Do **not** begin implementation; the user reviews and decides how to proceed.
+
+## Rules
+
+- **Never start work on a dirty tree.** The script's clean-tree refusal is the safety rail; do not bypass it with `--allow-dirty` workarounds.
+- **Never auto-pick a card** when multiple are available — always present the list and let the user choose.
+- **Never enter implementation** in this skill. The deliverable is the prepared workspace plus the draft plan.
+- **Confirm before transitioning state** on a card already `Active`, `Resolved`, `Closed`, or `Done`.
+- **Worktree is the default.** Only fall back to in-place branch creation when `--no-worktree` is explicit.

--- a/plugins/start-work/commands/start-work.md
+++ b/plugins/start-work/commands/start-work.md
@@ -93,7 +93,7 @@ GitHub has no formal state to transition — assignment is the active signal.
 ### ADO
 Use `mcp__azure-devops__wit_update_work_item` to:
 1. Set `System.State` to `Active`. Some teams use `In Progress` or another non-default state name — if the project's process template uses a non-`Active` next state, surface the choices and ask the user before guessing.
-2. Set `System.AssignedTo` to the current user (look up via `mcp__azure-devops__core_list_project_teams` with `mine=true` if the email isn't readily available, or use the user's `~/.claude/CLAUDE.md`-stored work email).
+2. Set `System.AssignedTo` to the current user. Source the user's email from `git config user.email` (run `git config user.email --get`) or from the email recorded in `~/.claude/CLAUDE.md`. Note: `mcp__azure-devops__core_list_project_teams` returns *teams*, not user identity — don't use it for this lookup.
 
 If the work item is already `Active` and assigned to the current user, this step is a no-op — log it and continue.
 

--- a/plugins/start-work/scripts/start-work.sh
+++ b/plugins/start-work/scripts/start-work.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Run Git Hygiene Before New Work and create the working branch (in a worktree by default).
+#
+# Usage:
+#   start-work.sh --slug <kebab-case-slug> [--id <issue-or-work-item-id>] [--base <branch>] [--no-worktree]
+#
+# Default behavior creates a worktree at .claude/worktrees/<id>-<slug>/ on a new branch
+# named branches/<id>-<slug>. With --no-worktree the branch is created in the current
+# checkout via `git checkout -b`. If --id is omitted (e.g., when no tracked issue/work
+# item exists), the branch is named branches/<slug>.
+#
+# On success, the last lines of stdout are:
+#   BRANCH=<branch>
+#   WORKTREE_PATH=<path>     (only in worktree mode)
+#
+# Refuses to run if the working tree is dirty, the target branch already exists
+# locally, or the target worktree path already exists.
+
+set -euo pipefail
+
+ID=""
+SLUG=""
+BASE="main"
+USE_WORKTREE=1
+
+usage() {
+    cat >&2 <<USAGE
+usage: $0 --slug <kebab-case-slug> [--id <issue-or-work-item-id>] [--base <branch>] [--no-worktree]
+
+Creates branches/<id>-<slug> (or branches/<slug> if --id is omitted) from clean
+origin/<base>. Worktree at .claude/worktrees/<id>-<slug>/ by default; --no-worktree
+creates the branch in the current checkout instead.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --id) ID="${2:-}"; shift 2;;
+        --slug) SLUG="${2:-}"; shift 2;;
+        --base) BASE="${2:-}"; shift 2;;
+        --no-worktree) USE_WORKTREE=0; shift;;
+        -h|--help) usage; exit 0;;
+        *) echo "unknown arg: $1" >&2; usage; exit 2;;
+    esac
+done
+
+if [ -z "$SLUG" ]; then
+    echo "error: --slug is required" >&2
+    usage
+    exit 2
+fi
+
+# Validate slug: kebab-case only — lowercase letters, digits, internal hyphens.
+if ! printf '%s' "$SLUG" | grep -Eq '^[a-z0-9]+(-[a-z0-9]+)*$'; then
+    echo "error: --slug '$SLUG' is not kebab-case (expected lowercase letters/digits, hyphens between words, no leading or trailing hyphens)" >&2
+    exit 2
+fi
+
+# Construct branch name and worktree dir name per the team's Branch Naming standard.
+if [ -n "$ID" ]; then
+    # Validate id is alphanumeric + hyphen so it can't inject path components.
+    if ! printf '%s' "$ID" | grep -Eq '^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$'; then
+        echo "error: --id '$ID' must be alphanumeric (with optional internal hyphens)" >&2
+        exit 2
+    fi
+    BRANCH="branches/$ID-$SLUG"
+    WT_DIR_NAME="$ID-$SLUG"
+else
+    BRANCH="branches/$SLUG"
+    WT_DIR_NAME="$SLUG"
+fi
+
+# Verify we are inside a git repo.
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "error: not inside a git repository" >&2
+    exit 1
+fi
+
+# Operate from the repo root so worktree paths resolve correctly.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Verify clean working tree — Git Hygiene Before New Work refuses to start on dirty state.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "error: working tree is dirty. Commit, stash, or discard changes before starting new work." >&2
+    git status --short >&2
+    exit 1
+fi
+
+# Refuse to clobber an existing local branch.
+if git rev-parse --verify --quiet "$BRANCH" >/dev/null; then
+    echo "error: branch '$BRANCH' already exists locally. Pick a different slug or delete the existing branch." >&2
+    exit 1
+fi
+
+# Fetch the base branch from origin. Capture stderr separately so a network failure
+# is reported clearly instead of merged into stdout (same pattern resolve_app_insights.sh uses).
+FETCH_ERR_FILE="$(mktemp)"
+trap 'rm -f "$FETCH_ERR_FILE"' EXIT
+
+if ! git fetch origin "$BASE" 2>"$FETCH_ERR_FILE" >&2; then
+    echo "error: 'git fetch origin $BASE' failed:" >&2
+    cat "$FETCH_ERR_FILE" >&2
+    exit 1
+fi
+
+if ! git rev-parse --verify --quiet "origin/$BASE" >/dev/null; then
+    echo "error: origin/$BASE does not exist after fetch. Verify --base is correct." >&2
+    exit 1
+fi
+
+if [ "$USE_WORKTREE" -eq 1 ]; then
+    WT_PATH=".claude/worktrees/$WT_DIR_NAME"
+    if [ -e "$WT_PATH" ]; then
+        echo "error: worktree path '$WT_PATH' already exists. Remove it (git worktree remove --force '$WT_PATH') or pick a different slug." >&2
+        exit 1
+    fi
+    mkdir -p "$(dirname "$WT_PATH")"
+    git worktree add -b "$BRANCH" "$WT_PATH" "origin/$BASE" >&2
+    echo "BRANCH=$BRANCH"
+    echo "WORKTREE_PATH=$WT_PATH"
+else
+    # In-place: branch directly off origin/<base> so we don't depend on local <base> being current.
+    git checkout -b "$BRANCH" "origin/$BASE" >&2
+    echo "BRANCH=$BRANCH"
+fi

--- a/plugins/start-work/scripts/start-work.sh
+++ b/plugins/start-work/scripts/start-work.sh
@@ -87,8 +87,8 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
     exit 1
 fi
 
-# Refuse to clobber an existing local branch.
-if git rev-parse --verify --quiet "$BRANCH" >/dev/null; then
+# Refuse to clobber an existing local branch (precise check against refs/heads/).
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
     echo "error: branch '$BRANCH' already exists locally. Pick a different slug or delete the existing branch." >&2
     exit 1
 fi
@@ -98,7 +98,7 @@ fi
 FETCH_ERR_FILE="$(mktemp)"
 trap 'rm -f "$FETCH_ERR_FILE"' EXIT
 
-if ! git fetch origin "$BASE" 2>"$FETCH_ERR_FILE" >&2; then
+if ! git fetch origin "$BASE" 2>"$FETCH_ERR_FILE"; then
     echo "error: 'git fetch origin $BASE' failed:" >&2
     cat "$FETCH_ERR_FILE" >&2
     exit 1
@@ -106,6 +106,16 @@ fi
 
 if ! git rev-parse --verify --quiet "origin/$BASE" >/dev/null; then
     echo "error: origin/$BASE does not exist after fetch. Verify --base is correct." >&2
+    exit 1
+fi
+
+# Refuse if the target branch already exists on origin (a teammate may have pushed
+# a same-named branch). Creating a divergent local copy here would silently set up
+# a force-push trap. The user can rename the slug or coordinate with the original
+# author before retrying.
+git fetch origin "$BRANCH" 2>/dev/null || true
+if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+    echo "error: branch '$BRANCH' already exists on origin (someone else may have pushed it). Pick a different slug or coordinate with the original author." >&2
     exit 1
 fi
 

--- a/plugins/start-work/scripts/test_start-work.sh
+++ b/plugins/start-work/scripts/test_start-work.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Smoke test for start-work.sh — usage error, slug validation, clean-tree refusal,
+# happy-path branch creation, --no-worktree mode, --base override, idempotency refusal.
+#
+# Uses a real local git repo as the fixture so we exercise actual `git worktree add`
+# and `git checkout -b` behavior. Sets `origin` to a bare repo on the same host.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUT="$SCRIPT_DIR/start-work.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "ok: $*"; }
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# Build a fresh git repo with a bare `origin` and one base commit on `main`.
+fresh_repo() {
+    local d="$TMP_ROOT/repo.$$.$RANDOM"
+    local bare="$TMP_ROOT/origin.$$.$RANDOM.git"
+    git init -q --bare "$bare"
+    git init -q -b main "$d"
+    (
+        cd "$d"
+        git config user.email "test@example.com"
+        git config user.name "Test"
+        # Opt out of the team's global pre-push hook for this throwaway test repo
+        # (the hook lives in ~/.git-hooks/pre-push and blocks pushes to main).
+        : > .allow-push-main
+        git remote add origin "$bare"
+        echo "seed" > README.md
+        git add README.md .allow-push-main
+        git commit -q -m "seed"
+        git push -q -u origin main
+    )
+    printf '%s' "$d"
+}
+
+# 1. Missing --slug exits with usage.
+if bash "$SUT" >/dev/null 2>&1; then
+    fail "expected non-zero exit on missing --slug"
+fi
+pass "usage error on missing --slug"
+
+# 2. Non-kebab-case slug is rejected (uppercase, leading hyphen, etc.).
+repo="$(fresh_repo)"
+if ( cd "$repo" && bash "$SUT" --slug "BadSlug" >/dev/null 2>&1 ); then
+    fail "expected rejection of uppercase slug"
+fi
+if ( cd "$repo" && bash "$SUT" --slug "-leading-hyphen" >/dev/null 2>&1 ); then
+    fail "expected rejection of leading-hyphen slug"
+fi
+if ( cd "$repo" && bash "$SUT" --slug "trailing-" >/dev/null 2>&1 ); then
+    fail "expected rejection of trailing-hyphen slug"
+fi
+pass "non-kebab-case slug rejected"
+
+# 3. Non-alphanumeric --id is rejected.
+if ( cd "$repo" && bash "$SUT" --slug "valid-slug" --id "bad/id" >/dev/null 2>&1 ); then
+    fail "expected rejection of --id with path separator"
+fi
+pass "id with path separator rejected"
+
+# 4. Dirty working tree is refused.
+repo="$(fresh_repo)"
+echo "dirt" > "$repo/uncommitted.txt"
+( cd "$repo" && git add uncommitted.txt )
+if ( cd "$repo" && bash "$SUT" --slug "anything" --id "1" >/dev/null 2>&1 ); then
+    fail "expected refusal on dirty tree"
+fi
+pass "dirty working tree refused"
+
+# 5. Happy path with --id: creates worktree at .claude/worktrees/<id>-<slug>/, branch
+#    branches/<id>-<slug>, prints BRANCH= and WORKTREE_PATH= on the last two stdout lines.
+repo="$(fresh_repo)"
+out="$( cd "$repo" && bash "$SUT" --slug "my-feature" --id "42" 2>/dev/null )"
+last="$(printf '%s\n' "$out" | tail -1)"
+prev="$(printf '%s\n' "$out" | tail -2 | head -1)"
+[ "$last" = "WORKTREE_PATH=.claude/worktrees/42-my-feature" ] \
+    || fail "expected WORKTREE_PATH on last line, got: $last"
+[ "$prev" = "BRANCH=branches/42-my-feature" ] \
+    || fail "expected BRANCH on second-to-last line, got: $prev"
+[ -d "$repo/.claude/worktrees/42-my-feature" ] \
+    || fail "expected worktree directory to exist"
+( cd "$repo/.claude/worktrees/42-my-feature" && [ "$(git branch --show-current)" = "branches/42-my-feature" ] ) \
+    || fail "expected worktree to be on branches/42-my-feature"
+pass "worktree-mode happy path with --id creates branches/<id>-<slug> at .claude/worktrees/<id>-<slug>"
+
+# 6. Happy path without --id: branch is branches/<slug>, worktree dir matches.
+repo="$(fresh_repo)"
+out="$( cd "$repo" && bash "$SUT" --slug "no-id-feature" 2>/dev/null )"
+last="$(printf '%s\n' "$out" | tail -1)"
+prev="$(printf '%s\n' "$out" | tail -2 | head -1)"
+[ "$last" = "WORKTREE_PATH=.claude/worktrees/no-id-feature" ] \
+    || fail "expected WORKTREE_PATH no-id-feature, got: $last"
+[ "$prev" = "BRANCH=branches/no-id-feature" ] \
+    || fail "expected BRANCH branches/no-id-feature, got: $prev"
+pass "no-id mode produces branches/<slug>"
+
+# 7. --no-worktree mode: branch in-place, no worktree dir, BRANCH= is the only stdout line.
+repo="$(fresh_repo)"
+out="$( cd "$repo" && bash "$SUT" --slug "in-place" --id "7" --no-worktree 2>/dev/null )"
+[ "$out" = "BRANCH=branches/7-in-place" ] \
+    || fail "expected BRANCH-only output in --no-worktree mode, got: $out"
+[ ! -d "$repo/.claude/worktrees/7-in-place" ] \
+    || fail "expected NO worktree directory in --no-worktree mode"
+( cd "$repo" && [ "$(git branch --show-current)" = "branches/7-in-place" ] ) \
+    || fail "expected current branch to be branches/7-in-place after --no-worktree"
+pass "--no-worktree mode creates branch in place, no worktree dir"
+
+# 8. --base override: create branch from a non-main base.
+repo="$(fresh_repo)"
+( cd "$repo" \
+    && git checkout -q -b feature/long-lived \
+    && echo "feature seed" > feature.txt \
+    && git add feature.txt \
+    && git commit -q -m "feature seed" \
+    && git push -q -u origin feature/long-lived \
+    && git checkout -q main )
+out="$( cd "$repo" && bash "$SUT" --slug "subfeature" --id "99" --base "feature/long-lived" 2>/dev/null )"
+last="$(printf '%s\n' "$out" | tail -1)"
+[ "$last" = "WORKTREE_PATH=.claude/worktrees/99-subfeature" ] \
+    || fail "expected --base override to still produce expected worktree path, got: $last"
+# Verify the new branch's parent is the feature branch tip, not main.
+( cd "$repo/.claude/worktrees/99-subfeature" \
+    && git merge-base --is-ancestor "origin/feature/long-lived" HEAD ) \
+    || fail "expected new branch to be rooted at origin/feature/long-lived"
+pass "--base <branch> roots the new branch off the specified base"
+
+# 9. Idempotency refusal: re-running with the same slug+id (worktree already exists) errors.
+repo="$(fresh_repo)"
+( cd "$repo" && bash "$SUT" --slug "idem" --id "11" >/dev/null 2>&1 )
+if ( cd "$repo" && bash "$SUT" --slug "idem" --id "11" >/dev/null 2>&1 ); then
+    fail "expected refusal on second run with same slug+id"
+fi
+pass "second run with same slug+id is refused (no silent overwrite)"
+
+# 10. Refusal when branch already exists locally even without a worktree.
+repo="$(fresh_repo)"
+( cd "$repo" && git branch branches/55-pre-existing )
+if ( cd "$repo" && bash "$SUT" --slug "pre-existing" --id "55" --no-worktree >/dev/null 2>&1 ); then
+    fail "expected refusal when target branch already exists locally"
+fi
+pass "refuses to clobber existing local branch"
+
+# 11. --base that doesn't exist on origin → clear error.
+repo="$(fresh_repo)"
+if ( cd "$repo" && bash "$SUT" --slug "x" --id "1" --base "no-such-branch" >/dev/null 2>&1 ); then
+    fail "expected non-zero exit when --base doesn't exist on origin"
+fi
+pass "non-existent --base is rejected"
+
+echo "all smoke tests passed"

--- a/plugins/start-work/scripts/test_start-work.sh
+++ b/plugins/start-work/scripts/test_start-work.sh
@@ -151,4 +151,30 @@ if ( cd "$repo" && bash "$SUT" --slug "x" --id "1" --base "no-such-branch" >/dev
 fi
 pass "non-existent --base is rejected"
 
+# 12. Branch already exists on origin (but not locally) → refuse with a coordination hint.
+#     A second clone of the same origin pushes the target branch, then the script tries
+#     to create the same branch in the first clone — should refuse rather than silently
+#     create a divergent local copy.
+repo="$(fresh_repo)"
+# Find this repo's bare origin so we can clone a second working copy that pushes the conflict.
+bare_origin="$( cd "$repo" && git remote get-url origin )"
+collaborator="$TMP_ROOT/collab.$$.$RANDOM"
+git clone -q "$bare_origin" "$collaborator"
+( cd "$collaborator" \
+    && git config user.email "collab@example.com" \
+    && git config user.name "Collab" \
+    && : > .allow-push-main \
+    && git checkout -q -b branches/77-conflicting \
+    && echo "collab work" > collab.txt \
+    && git add collab.txt \
+    && git commit -q -m "collab seed" \
+    && git push -q -u origin branches/77-conflicting )
+err="$( cd "$repo" && bash "$SUT" --slug "conflicting" --id "77" 2>&1 >/dev/null || true )"
+echo "$err" | grep -qi "already exists on origin" \
+    || fail "expected origin-side collision error, got: $err"
+# And no worktree should have been created locally as a side effect.
+[ ! -d "$repo/.claude/worktrees/77-conflicting" ] \
+    || fail "expected NO worktree to be created when origin already has the branch"
+pass "branch already on origin (but not local) is refused"
+
 echo "all smoke tests passed"


### PR DESCRIPTION
## Summary
Bookend to `/craft-pr`. Encodes the team's `Git Hygiene Before New Work`, `Branch Naming and PR Linking`, and `Mark Work Items Active` procedures from `standards/CLAUDE.md` so every developer lands on the same starting line when picking up a card. Same dual-source GitHub-or-ADO pattern as `/improve-stories`.

## Files
- `plugins/start-work/commands/start-work.md` — 8-step handler: parse args → source detection → card fetch → slug derivation → script invocation → enter worktree → mark active → codebase research → draft-plan handoff
- `plugins/start-work/scripts/start-work.sh` — deterministic git plumbing: clean-tree refusal, fetch `origin/<base>`, branch creation, worktree creation
- `plugins/start-work/scripts/test_start-work.sh` — 11 smoke-test assertions against a real local git repo with a bare origin
- `plugins/start-work/.claude-plugin/plugin.json` + `README.md` + marketplace entry

## Three design calls (confirmed at proposal time)
1. **Naming:** `start-work` — most discoverable, parallels `improve-stories`'s verb-noun pattern. `craft-start` reads awkwardly; `pickup-card` is too card-specific.
2. **Worktree by default** — opt-out via `--no-worktree`. Worktrees keep parallel multi-task work cleanly isolated; the team standard's branch naming (`branches/<id>-<slug>`) is preserved either way.
3. **`--base <branch>` flag** (default `main`) — folds in the comment on the issue from `@reggaeguitar`. Symmetric with `/craft-pr`'s `--base`.

## Behavior on a real card

```
/start-work #29
```

1. Detects GitHub source (issue prefix `#`); fetches title, description, state, labels, assignees.
2. Derives kebab-case slug from the title (≤ 50 chars, word-boundary truncated).
3. Runs `start-work.sh`: refuses if working tree is dirty, fetches `origin/main`, creates branch `branches/29-<slug>` rooted at `origin/main`, creates a worktree at `.claude/worktrees/29-<slug>/`.
4. Switches the session into the new worktree via `EnterWorktree`.
5. `gh issue edit 29 --add-assignee @me` (state-guard: asks first if the issue is already assigned to someone else).
6. `Explore` subagent returns a punch list of touched files based on the card title + description.
7. Hands off a structured draft plan: card summary, workspace info, research findings, 3-7 numbered implementation steps, suggested next action. **Stops without starting implementation.**

## Test plan
- [x] Smoke tests pass (11 assertions): usage error, slug validation, id path-separator rejection, dirty-tree refusal, worktree happy path with `--id`, no-id mode (`branches/<slug>` without prefix), `--no-worktree` mode, `--base` override against a real feature branch, idempotency refusal on second run, existing-local-branch refusal, non-existent base rejection. Tests use a real local git repo with a bare origin — not stubs.
- [x] Bash + JSON syntax validated.
- [x] `gh issue view` field shape verified against issue #124 to confirm the handler's expected JSON keys are correct.
- [ ] **Live end-to-end test** (`/start-work` invoked post-install against a real card) deferred to first real use — same pattern as PR #125. Cannot run pre-merge because the plugin isn't installable until the marketplace publishes it.

Closes #124