### PR TITLE
Add Claude Code usage report tooling

### DIFF
--- a/docs/claude-usage-howto.md
+++ b/docs/claude-usage-howto.md
@@ -1,0 +1,141 @@
+# Claude Code Usage Report — Team Member Guide
+
+Run this to produce a per-developer Claude Code usage baseline. Useful as
+input to a team-subscription cost analysis: per-day, per-model, and
+per-5-hour-block breakdowns of the API-rate-equivalent cost recorded in your
+local Claude Code transcripts. Share the aggregate JSON with whoever is
+collecting team baselines; the full markdown summary stays on your machine.
+
+## What this does
+
+Walks `~/.claude/projects/` (your local Claude Code transcripts), aggregates
+tokens by day, by model, and by 5-hour block via [ccusage](https://github.com/ryoppippi/ccusage),
+applies current Anthropic API pricing, and produces:
+
+- `<youruser>-summary.md` — one-page report with daily timeline, per-model
+  split, 5-hour-block distribution, and token totals. **Keep this for yourself.**
+- `<youruser>-aggregate.json` — totals + percentiles + per-day cost timeline,
+  no transcript content. **Share this with whoever is collecting team baselines.**
+
+Cost figures are *API-rate equivalent* — what your usage would have cost
+pay-per-token. The point of the team-subscription analysis is to compare these
+numbers against flat-rate plan options.
+
+All ccusage calls use `--timezone UTC` and `--mode calculate` so each
+developer's aggregate is comparable regardless of where they ran the script.
+
+## One-time setup
+
+Both Node.js and Python are required. Most dev machines already have them.
+
+1. Confirm Node.js: `node --version` (any recent LTS is fine).
+2. Confirm Python 3.9+: `python3 --version` or `python --version`. **If your
+   `python` reports 2.x, install Python 3 from python.org** — the script does
+   not run on Python 2.
+3. Install ccusage globally so subsequent runs are fast:
+
+   ```bash
+   npm install -g ccusage
+   ```
+
+   On macOS or Linux installs that use the system Node, this may need `sudo`:
+   `sudo npm install -g ccusage`. If you use nvm, asdf, or a per-user prefix
+   (`npm config set prefix ~/.npm-global`) sudo isn't needed.
+
+   Verify: `ccusage --version`
+
+If you skip step 3, the script falls back to `npx -y ccusage@latest`, which
+works but adds ~60 seconds of download to every run.
+
+## Run
+
+> **Pick an output directory outside the repo working tree.** The script writes
+> two files containing your dollar amounts and daily timeline. Don't run it in
+> the repo root — accidental `git add -A` commits personal data.
+
+```bash
+python3 scripts/claude-usage-report.py --out-dir ~/claude-usage
+```
+
+Default window is the last 60 days. Two files appear in `~/claude-usage/`:
+`<youruser>-summary.md` and `<youruser>-aggregate.json`.
+
+### Common overrides
+
+```bash
+# Custom window
+python3 scripts/claude-usage-report.py --since 2026-03-01 --until 2026-04-30 \
+    --out-dir ~/claude-usage
+
+# Custom output filename prefix (defaults to your OS username, sanitized)
+python3 scripts/claude-usage-report.py --user firstname-lastname \
+    --out-dir ~/claude-usage
+
+# Force ccusage to fetch fresh pricing (recommended after a model launch)
+python3 scripts/claude-usage-report.py --ccusage 'ccusage --no-offline' \
+    --out-dir ~/claude-usage
+```
+
+## What to send back
+
+Share the **`<youruser>-aggregate.json`** file with whoever is collecting
+team baselines. Keep the `<youruser>-summary.md` for your own records.
+
+The aggregate JSON contains:
+
+- Window dates (UTC) and total token counts (input, output, cache read, cache write)
+- Per-model cost breakdown (e.g., how much of your spend is Opus vs Sonnet vs Haiku)
+- Daily statistics (min, avg, p95, max) and a per-day cost timeline
+- 5-hour block percentiles and a bucketed distribution
+- Tooling provenance: `schema_version`, `ccusage_version`, `cost_mode`, `timezone`
+  — so cross-seat comparisons are auditable
+
+It does **not** contain transcript content, project names, branch names, or
+working directory paths. The script never invokes ccusage with `-i`/`--instances`,
+so per-project breakdowns are not computed.
+
+## Privacy
+
+- The aggregate JSON intentionally excludes per-project breakdown.
+- Do **not** run ccusage with `-i, --instances` and share that output unless
+  whoever's collecting baselines explicitly asks. That flag exposes which
+  repos you've worked on.
+- The summary markdown's daily timeline contains dates and dollar amounts only.
+  Share it if asked, but it's not required for the team analysis.
+
+## Troubleshooting
+
+**"It looks like the script hung."** First run downloads ~50MB of npm packages
+through `npx` with no progress indicator. If you ran `npm install -g ccusage`
+during setup, subsequent runs should complete in <30 seconds. If you still
+suspect a hang, narrow the window with `--since`.
+
+**"Pricing missing for model X"** or unfamiliar model names in the breakdown.
+ccusage's pricing table may lag a few weeks behind newly-released models. Re-run
+with `--ccusage 'ccusage --no-offline'` to force fresh pricing from the API.
+
+**"`ccusage`: command not found"** but you ran `npm install -g ccusage`.
+Your shell may not have picked up the new PATH. Open a new terminal, or use
+the npx fallback: `--ccusage 'npx -y ccusage@latest'`.
+
+**"`python`: command not found"** — try `python3` instead. Modern macOS and
+some Linux distros omit the `python` alias and only ship `python3`.
+
+**"Python 3.9+ required"** — the script uses modern type-hint syntax. Any
+Python 3.9+ should work; no pip dependencies needed (stdlib only).
+
+**"No Claude Code transcripts found"** — you may not have used Claude Code in
+the default 60-day window. Try `--since 2026-01-01` (or however far back your
+usage goes) to widen.
+
+**"`error: --until ... is before --since ...`"** — the window is inverted.
+Swap the arguments.
+
+## Background
+
+This tool was built to support a team-subscription cost analysis: rather than
+guessing per-developer Claude Code usage, capture each developer's actual
+per-day, per-model, and per-5-hour-block spend, then compare against flat-rate
+subscription tiers. It emits no transcript content — only aggregated cost and
+token totals — so it's safe to share aggregates across a team without exposing
+the work the developer was doing.

--- a/scripts/claude-throttle-audit.py
+++ b/scripts/claude-throttle-audit.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Throttle / API-error audit for Claude Code transcripts.
+
+Diagnostic tool — companion to claude-usage-report.py. Surfaces server-side
+errors and feature gates from session transcripts, useful when investigating
+why specific Claude Code requests failed during a given window.
+
+Scans ~/.claude/projects/**/*.jsonl for API error events that Claude Code
+logs into the session transcripts. Reports a per-month and per-status-code
+timeline, with each event classified by category.
+
+LIMITATION (important to understand before relying on the output):
+  Claude Code does NOT log plan-level cap hits (weekly / 5-hour limits) into
+  the session jsonl files. Those notifications appear in the UI / status bar
+  only. The events this script CAN detect are:
+    - server_per_second_throttle  (Anthropic API per-minute rate limit, 429)
+    - extra_usage_required        (1M-context feature gate, 429)
+    - anthropic_overload          (server-side fleet overload, 529)
+    - server_error / service_unavailable  (5xx)
+  For authoritative plan-cap counts, see the Anthropic Console usage page.
+
+Usage:
+  python scripts/claude-throttle-audit.py [--since YYYY-MM-DD] [--until YYYY-MM-DD]
+                                          [--user NAME] [--out-dir PATH]
+
+Outputs:
+  <user>-throttle-summary.md     human-readable per-month + per-category report
+  <user>-throttle-aggregate.json structured totals (no transcript content)
+
+Re-uses parse_iso_date / sanitize_user / derive_user from claude-usage-report.py
+to avoid duplication.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+
+SCHEMA_VERSION = 2
+
+
+def _load_usage_module():
+    """Load claude-usage-report.py for shared utilities (the hyphen blocks `import`)."""
+    script_path = Path(__file__).parent / "claude-usage-report.py"
+    spec = importlib.util.spec_from_file_location("claude_usage_report", script_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("claude_usage_report", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+_usage = _load_usage_module()
+parse_iso_date = _usage.parse_iso_date
+sanitize_user = _usage.sanitize_user
+derive_user = _usage.derive_user
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    default_since = (date.today() - timedelta(days=60)).isoformat()
+    default_until = date.today().isoformat()
+    parser.add_argument("--since", default=default_since, type=parse_iso_date,
+                        help="Window start (YYYY-MM-DD). Default: 60 days ago.")
+    parser.add_argument("--until", default=default_until, type=parse_iso_date,
+                        help="Window end (YYYY-MM-DD). Default: today.")
+    parser.add_argument("--user", default=None,
+                        help="Output filename prefix (default: $USER / $USERNAME, sanitized).")
+    parser.add_argument("--out-dir", default=".",
+                        help="Output directory (default: current dir). Recommended: outside the repo.")
+    parser.add_argument("--projects-dir", default=None,
+                        help="Override Claude Code transcripts directory (default: ~/.claude/projects).")
+    return parser.parse_args()
+
+
+def find_jsonl_files(projects_dir: Path) -> list[Path]:
+    if not projects_dir.exists():
+        return []
+    return list(projects_dir.rglob("*.jsonl"))
+
+
+def date_from_http_headers(headers: dict) -> str | None:
+    """Convert HTTP `Date` header (RFC 7231 format) to ISO8601 string with Z suffix."""
+    raw = headers.get("date")
+    if not raw:
+        return None
+    try:
+        dt = datetime.strptime(raw, "%a, %d %b %Y %H:%M:%S GMT")
+        return dt.isoformat() + "Z"
+    except ValueError:
+        return None
+
+
+def classify_event(status, text: str) -> str:
+    """Map (status, message text) to an actionable category.
+
+    Distinct from raw HTTP status because the same status (429) covers very
+    different operational meanings — per-minute server throttling vs feature
+    gate vs plan-cap. The text is the disambiguator.
+    """
+    text_lower = (text or "").lower()
+    if "extra usage is required" in text_lower:
+        return "extra_usage_required"
+    if "server is temporarily limiting" in text_lower:
+        return "server_per_second_throttle"
+    if status == 529 or "overloaded" in text_lower:
+        return "anthropic_overload"
+    if status == 503:
+        return "service_unavailable"
+    if status == 500 or "internal server error" in text_lower:
+        return "server_error"
+    if status == 429:
+        return "rate_limit_unspecified"
+    if status is not None:
+        return f"http_{status}"
+    return "unclassified"
+
+
+def _extract_text(message: dict) -> str:
+    """Concatenate all text-type content blocks from an assistant message."""
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            parts.append(block.get("text") or "")
+    return "".join(parts)
+
+
+def extract_error_events(line: str) -> list[dict]:
+    """Return zero or more error-event dicts from a single JSONL line.
+
+    Recognized shapes (both can co-occur for the same underlying error):
+
+    1. system-level structured error log:
+       {"type":"system", "subtype":"api_error", "level":"error",
+        "error":{"status":NNN, "headers":{...}}}
+
+    2. assistant-message-level error attribute:
+       {"type":"assistant", "isApiErrorMessage":true, "apiErrorStatus":NNN,
+        "error":"rate_limit"|"server_error"|...,
+        "message":{"content":[{"type":"text","text":"API Error: ..."}]}}
+
+    Per the file-level docstring, this does NOT capture Claude Code plan-cap
+    hits (weekly / 5-hour) — those go through UI notifications, not transcripts.
+    """
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        return []
+
+    events: list[dict] = []
+
+    # Shape 1: system-level api_error
+    if obj.get("subtype") == "api_error":
+        err = obj.get("error")
+        if isinstance(err, dict):
+            timestamp = obj.get("timestamp") or date_from_http_headers(err.get("headers") or {})
+            status = err.get("status")
+            events.append({
+                "kind": "api_error_system",
+                "status": status,
+                "error_type": None,
+                "category": classify_event(status, ""),
+                "timestamp": timestamp,
+                "model": (obj.get("message") or {}).get("model"),
+            })
+
+    # Shape 2: assistant-message-level error attribute
+    if obj.get("isApiErrorMessage") is True:
+        status = obj.get("apiErrorStatus")
+        error_type = obj.get("error") if isinstance(obj.get("error"), str) else None
+        text = _extract_text(obj.get("message") or {})
+        events.append({
+            "kind": "api_error_message",
+            "status": status,
+            "error_type": error_type,
+            "category": classify_event(status, text),
+            "timestamp": obj.get("timestamp"),
+            # Synthetic recovery messages carry model="<synthetic>", not informative.
+            "model": None,
+        })
+
+    return events
+
+
+def in_window(timestamp: str | None, since_dt: datetime, until_dt: datetime) -> bool:
+    """Test whether an event timestamp falls in [since, until) using naive UTC."""
+    if not timestamp:
+        return False
+    try:
+        ts = datetime.fromisoformat(timestamp.replace("Z", "+00:00")).replace(tzinfo=None)
+    except ValueError:
+        return False
+    return since_dt <= ts < until_dt
+
+
+def summarize_events(events: list[dict], since: str, until: str) -> dict:
+    by_month: dict[str, Counter] = defaultdict(Counter)
+    by_status: Counter = Counter()
+    by_kind: Counter = Counter()
+    by_category: Counter = Counter()
+    timeline: list[dict] = []
+
+    for event in events:
+        ts = event.get("timestamp") or ""
+        month = ts[:7] if len(ts) >= 7 else "unknown"
+        kind = event.get("kind", "unknown")
+        category = event.get("category", "unclassified")
+        status = event.get("status")
+
+        by_month[month][category] += 1
+        if status:
+            by_status[status] += 1
+        by_kind[kind] += 1
+        by_category[category] += 1
+        timeline.append({
+            "timestamp": ts,
+            "kind": kind,
+            "status": status,
+            "category": category,
+            "error_type": event.get("error_type"),
+            "model": event.get("model"),
+        })
+
+    timeline.sort(key=lambda x: x.get("timestamp") or "")
+
+    return {
+        "window": {"since": since, "until": until},
+        "total_events": len(events),
+        "by_kind": dict(by_kind),
+        "by_status": {str(k): v for k, v in by_status.items()},
+        "by_category": dict(by_category),
+        "by_month": {month: dict(counts) for month, counts in sorted(by_month.items())},
+        "timeline": timeline,
+    }
+
+
+CATEGORY_MEANING = {
+    "server_per_second_throttle": "Anthropic API per-minute rate limit (transient, NOT plan cap)",
+    "extra_usage_required": "Feature gate (e.g., 1M context requires extra usage on account)",
+    "anthropic_overload": "Anthropic fleet overloaded (server-side, not your plan)",
+    "server_error": "5xx server error (transient)",
+    "service_unavailable": "503 service unavailable (transient)",
+    "rate_limit_unspecified": "Status 429 with unrecognized message text",
+    "unclassified": "No status code; synthetic recovery only",
+}
+
+
+def render_markdown(summary: dict, user: str) -> str:
+    window = summary["window"]
+    lines = [
+        f"# Claude Code Throttle Audit - {user}",
+        "",
+        f"**Window:** {window['since']} to {window['until']} (UTC)",
+        f"**Generated:** {summary.get('generated', date.today().isoformat())}",
+        f"**Schema:** v{summary['schema_version']}",
+        "",
+        "> **LIMITATION:** This audit captures server-side errors, per-minute API",
+        "> throttling, and feature gates from Claude Code's session transcripts.",
+        "> It does NOT detect weekly or 5-hour plan-cap hits — those notifications",
+        "> appear in the Claude Code UI without writing to the session log. For",
+        "> authoritative plan-cap counts, see the Anthropic Console usage page.",
+        "",
+        "## Summary",
+        "",
+        f"- Total error events: **{summary['total_events']}**",
+    ]
+
+    if summary["total_events"] == 0:
+        lines += [
+            "",
+            "_No API error events found in the window._",
+            "",
+        ]
+        return "\n".join(lines) + "\n"
+
+    if summary.get("by_category"):
+        lines += [
+            "",
+            "### By category",
+            "",
+            "| Category | Count | Meaning |",
+            "| --- | ---: | --- |",
+        ]
+        for category, count in sorted(summary["by_category"].items(), key=lambda kv: -kv[1]):
+            meaning = CATEGORY_MEANING.get(category, "")
+            lines.append(f"| `{category}` | {count} | {meaning} |")
+
+    if summary.get("by_status"):
+        lines += [
+            "",
+            "### By HTTP status",
+            "",
+            "| Status | Count |",
+            "| ---: | ---: |",
+        ]
+        for status, count in sorted(summary["by_status"].items(), key=lambda kv: -kv[1]):
+            lines.append(f"| {status} | {count} |")
+
+    if summary.get("by_month"):
+        lines += [
+            "",
+            "### By month",
+            "",
+            "| Month | Total | Breakdown |",
+            "| --- | ---: | --- |",
+        ]
+        for month, counts in sorted(summary["by_month"].items()):
+            total = sum(counts.values())
+            breakdown = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+            lines.append(f"| {month} | {total} | {breakdown} |")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    if args.until < args.since:
+        sys.exit(f"error: --until ({args.until}) is before --since ({args.since}).")
+
+    user = sanitize_user(args.user) if args.user else derive_user()
+    out_dir = Path(args.out_dir).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    projects_dir = (Path(args.projects_dir).expanduser() if args.projects_dir
+                    else Path.home() / ".claude" / "projects")
+    files = find_jsonl_files(projects_dir)
+    print(f"Scanning {len(files)} jsonl files under {projects_dir}", file=sys.stderr)
+    print("NOTE: this audit does NOT capture plan-cap hits (weekly / 5-hour). "
+          "See the Anthropic Console for those.", file=sys.stderr)
+
+    since_dt = datetime.strptime(args.since, "%Y-%m-%d")
+    until_dt = datetime.strptime(args.until, "%Y-%m-%d") + timedelta(days=1)
+
+    all_events: list[dict] = []
+    for fp in files:
+        try:
+            with open(fp, "r", encoding="utf-8") as f:
+                for line in f:
+                    for event in extract_error_events(line):
+                        if in_window(event.get("timestamp"), since_dt, until_dt):
+                            all_events.append(event)
+        except OSError:
+            continue
+
+    summary = summarize_events(all_events, args.since, args.until)
+    summary["schema_version"] = SCHEMA_VERSION
+    summary["user"] = user
+    summary["generated"] = date.today().isoformat()
+
+    md_path = out_dir / f"{user}-throttle-summary.md"
+    json_path = out_dir / f"{user}-throttle-aggregate.json"
+    md_path.write_text(render_markdown(summary, user), encoding="utf-8")
+    json_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Wrote {md_path}")
+    print(f"Wrote {json_path}")
+    print(f"Total events: {summary['total_events']}")
+    if summary.get("by_category"):
+        for category, count in sorted(summary["by_category"].items(), key=lambda kv: -kv[1]):
+            print(f"  {category}: {count}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/claude-usage-report.py
+++ b/scripts/claude-usage-report.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Claude Code usage summary, wrapping ccusage.
+
+Produces a per-seat baseline suitable for team-subscription cost analysis.
+Walks ~/.claude/projects/**/*.jsonl via ccusage and emits two files:
+
+  <user>-summary.md      one-page markdown report (per-day + per-block stats)
+  <user>-aggregate.json  mailable totals (no transcript content, no project names)
+
+Usage:
+  python scripts/claude-usage-report.py [--since YYYY-MM-DD] [--until YYYY-MM-DD]
+                                        [--user NAME] [--out-dir PATH]
+                                        [--ccusage 'CMD ARGS']
+
+Defaults:
+  --since   60 days ago
+  --until   today
+  --user    derived from $USER / $USERNAME (sanitized to [a-z0-9_-])
+  --out-dir current directory (recommend a path outside the repo)
+  --ccusage 'ccusage' if on PATH, else 'npx -y ccusage@latest'
+
+All ccusage calls use --timezone UTC and --mode calculate so cross-seat
+aggregates are comparable regardless of where the developer ran the script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+
+SCHEMA_VERSION = 2
+COST_MODE = "calculate"
+TIMEZONE = "UTC"
+SAFE_USER_RE = re.compile(r"[^a-z0-9_-]")
+
+
+def parse_iso_date(value: str) -> str:
+    """argparse `type=` callable: validate YYYY-MM-DD and return the original string."""
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"invalid date {value!r}: expected YYYY-MM-DD"
+        )
+    return value
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    default_since = (date.today() - timedelta(days=60)).isoformat()
+    default_until = date.today().isoformat()
+    parser.add_argument("--since", default=default_since, type=parse_iso_date,
+                        help="Window start (YYYY-MM-DD). Default: 60 days ago.")
+    parser.add_argument("--until", default=default_until, type=parse_iso_date,
+                        help="Window end (YYYY-MM-DD). Default: today.")
+    parser.add_argument("--user", default=None,
+                        help="Output filename prefix (default: $USER / $USERNAME, sanitized).")
+    parser.add_argument("--out-dir", default=".",
+                        help=("Output directory (default: current dir). Recommended: a path "
+                              "outside the repo working tree (e.g., ~/claude-usage)."))
+    parser.add_argument("--ccusage", default=None,
+                        help=("Override ccusage command. Default: 'ccusage' if on PATH, "
+                              "else 'npx -y ccusage@latest'. Pass extra args via quotes, "
+                              "e.g. --ccusage 'ccusage --no-offline'."))
+    return parser.parse_args()
+
+
+def to_yyyymmdd(iso: str) -> str:
+    return datetime.strptime(iso, "%Y-%m-%d").strftime("%Y%m%d")
+
+
+def sanitize_user(value: str) -> str:
+    """Reduce a username to filesystem-safe characters [a-z0-9_-].
+
+    Used both for env-derived names ($USER / $USERNAME) and explicit --user.
+    Path separators, dots, and other unsafe characters are replaced with `_`.
+    Falls back to "user" if the result is empty.
+    """
+    cleaned = SAFE_USER_RE.sub("_", value.strip().lower().replace(" ", "_"))
+    cleaned = cleaned.strip("_")
+    return cleaned or "user"
+
+
+def derive_user() -> str:
+    for var in ("USER", "USERNAME"):
+        value = os.environ.get(var)
+        if value:
+            return sanitize_user(value)
+    return "user"
+
+
+def resolve_ccusage(override: str | None) -> list[str]:
+    if override is not None:
+        parts = override.split()
+        if not parts:
+            sys.exit("error: --ccusage cannot be empty or whitespace-only")
+        # Resolve the first token via shutil.which so Windows .cmd shims work.
+        resolved = shutil.which(parts[0])
+        if resolved:
+            parts[0] = resolved
+        return parts
+    ccusage_path = shutil.which("ccusage")
+    if ccusage_path:
+        return [ccusage_path]
+    npx_path = shutil.which("npx")
+    if npx_path:
+        return [npx_path, "-y", "ccusage@latest"]
+    sys.exit("error: neither 'ccusage' nor 'npx' on PATH. "
+             "Install Node.js then run: npm install -g ccusage")
+
+
+def run_ccusage(cmd: list[str], subcommand: str, extra: list[str]) -> dict:
+    args = cmd + [subcommand, "--json"] + extra
+    try:
+        result = subprocess.run(
+            args, capture_output=True, text=True, check=False, timeout=900,
+        )
+    except FileNotFoundError as exc:
+        sys.exit(f"error: could not run ccusage ({exc}). "
+                 "Install with: npm install -g ccusage")
+    except subprocess.TimeoutExpired:
+        sys.exit("error: ccusage timed out after 15 minutes. "
+                 "Try narrowing the window with --since.")
+    if result.returncode != 0:
+        sys.exit(f"error: ccusage exited {result.returncode}\n"
+                 f"command: {' '.join(args)}\n"
+                 f"stderr: {result.stderr.strip()}")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        sys.exit(f"error: ccusage produced invalid JSON: {exc}\n"
+                 f"first 200 chars: {result.stdout[:200]!r}")
+
+
+def get_ccusage_version(cmd: list[str]) -> str:
+    """Best-effort capture of the ccusage version string for the audit trail."""
+    try:
+        result = subprocess.run(
+            cmd + ["--version"], capture_output=True, text=True,
+            timeout=120, check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return "unknown"
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    sorted_values = sorted(values)
+    k = (len(sorted_values) - 1) * pct / 100.0
+    floor_index = int(k)
+    ceil_index = min(floor_index + 1, len(sorted_values) - 1)
+    fraction = k - floor_index
+    return sorted_values[floor_index] + (sorted_values[ceil_index] - sorted_values[floor_index]) * fraction
+
+
+def bucketize(costs: list[float]) -> dict[str, int]:
+    edges = [0, 1, 5, 10, 25, 50, 100, 200, 500, float("inf")]
+    labels = ["<$1", "$1-5", "$5-10", "$10-25", "$25-50",
+              "$50-100", "$100-200", "$200-500", "$500+"]
+    counts = [0] * len(labels)
+    for cost in costs:
+        # Negative costs aren't expected from ccusage; clamp to 0 so the bucket
+        # totals always sum to len(costs) instead of silently dropping inputs.
+        clamped = max(cost, 0.0)
+        for i in range(len(edges) - 1):
+            if edges[i] <= clamped < edges[i + 1]:
+                counts[i] += 1
+                break
+    return dict(zip(labels, counts))
+
+
+def summarize_daily(daily_data: dict, since: str, until: str) -> dict:
+    daily = daily_data.get("daily") or []
+    totals = daily_data.get("totals") or {}
+
+    # `or 0.0` guards against `{"totalCost": null}` — `dict.get(k, default)`
+    # returns the explicit None, not the default, when the key exists.
+    daily_costs = [(d.get("totalCost") or 0.0) for d in daily]
+    window_days = (datetime.strptime(until, "%Y-%m-%d")
+                   - datetime.strptime(since, "%Y-%m-%d")).days + 1
+    active_days = sum(1 for c in daily_costs if c > 0)
+    reported_total = totals.get("totalCost")
+    total_cost = sum(daily_costs) if reported_total is None else reported_total
+    avg_daily = total_cost / window_days if window_days > 0 else 0.0
+    p95_daily = percentile(daily_costs, 95)
+    monthly_projection = avg_daily * 30
+
+    model_totals: dict[str, float] = {}
+    for entry in daily:
+        for breakdown in entry.get("modelBreakdowns") or []:
+            name = breakdown.get("modelName") or "unknown"
+            cost = breakdown.get("cost") or 0.0
+            model_totals[name] = model_totals.get(name, 0.0) + cost
+
+    return {
+        "window": {"since": since, "until": until, "days": window_days},
+        "active_days": active_days,
+        "totals": {
+            "cost_usd": round(total_cost, 2),
+            "input_tokens": totals.get("inputTokens") or 0,
+            "output_tokens": totals.get("outputTokens") or 0,
+            "cache_creation_tokens": totals.get("cacheCreationTokens") or 0,
+            "cache_read_tokens": totals.get("cacheReadTokens") or 0,
+        },
+        "daily_stats": {
+            "min": round(min(daily_costs, default=0.0), 2),
+            "avg": round(avg_daily, 2),
+            "p95": round(p95_daily, 2),
+            "max": round(max(daily_costs, default=0.0), 2),
+        },
+        "monthly_projection_usd": round(monthly_projection, 2),
+        "per_model_cost_usd": {
+            k: round(v, 2)
+            for k, v in sorted(model_totals.items(), key=lambda kv: -kv[1])
+        },
+        "daily_timeline": [
+            {"date": d.get("date"), "cost_usd": round((d.get("totalCost") or 0.0), 2)}
+            for d in daily
+        ],
+    }
+
+
+def summarize_blocks(blocks_data: dict) -> dict:
+    """Aggregate block stats. Window filtering is performed by ccusage itself
+    via --since/--until/--timezone; this function only consumes pre-filtered
+    data and skips gap blocks."""
+    blocks = [b for b in (blocks_data.get("blocks") or [])
+              if not b.get("isGap", False)]
+    costs = [(b.get("costUSD") or 0.0) for b in blocks]
+    if not costs:
+        return {
+            "total_blocks": 0,
+            "buckets": bucketize([]),
+            "percentiles_usd": {"p50": 0.0, "p75": 0.0, "p90": 0.0, "p95": 0.0, "p99": 0.0},
+            "max_block_usd": 0.0,
+            "mean_block_usd": 0.0,
+        }
+    return {
+        "total_blocks": len(blocks),
+        "buckets": bucketize(costs),
+        "percentiles_usd": {
+            "p50": round(percentile(costs, 50), 2),
+            "p75": round(percentile(costs, 75), 2),
+            "p90": round(percentile(costs, 90), 2),
+            "p95": round(percentile(costs, 95), 2),
+            "p99": round(percentile(costs, 99), 2),
+        },
+        "max_block_usd": round(max(costs), 2),
+        "mean_block_usd": round(sum(costs) / len(costs), 2),
+    }
+
+
+def render_markdown(summary: dict, user: str) -> str:
+    window = summary["window"]
+    totals = summary["totals"]
+    stats = summary["daily_stats"]
+    blocks = summary.get("block_stats", {})
+
+    lines = [
+        f"# Claude Code Usage Report - {user}",
+        "",
+        f"**Window:** {window['since']} to {window['until']} "
+        f"({window['days']} days, {summary.get('timezone', TIMEZONE)})",
+        f"**Generated:** {summary.get('generated', date.today().isoformat())}",
+        f"**Schema:** v{summary['schema_version']}",
+        f"**ccusage:** {summary.get('ccusage_version', 'unknown')} "
+        f"(mode: {summary.get('cost_mode', COST_MODE)})",
+        "",
+        "## Summary",
+        "",
+        f"- Total spend (API-rate equivalent): **${totals['cost_usd']:,.2f}**",
+        f"- Active days: {summary['active_days']} of {window['days']}",
+        f"- Daily spend - avg: ${stats['avg']:,.2f}, p95: ${stats['p95']:,.2f}, max: ${stats['max']:,.2f}",
+        f"- Monthly projection (avg x 30): **${summary['monthly_projection_usd']:,.2f}**",
+        "",
+        "## Per-model split",
+        "",
+        "| Model | Cost | Share |",
+        "| --- | ---: | ---: |",
+    ]
+    total = totals["cost_usd"] or 1.0
+    for model, cost in summary["per_model_cost_usd"].items():
+        share = (cost / total) * 100
+        lines.append(f"| `{model}` | ${cost:,.2f} | {share:.1f}% |")
+
+    lines += [
+        "",
+        "## Token totals",
+        "",
+        f"- Input: {totals['input_tokens']:,}",
+        f"- Output: {totals['output_tokens']:,}",
+        f"- Cache write: {totals['cache_creation_tokens']:,}",
+        f"- Cache read: {totals['cache_read_tokens']:,}",
+        "",
+    ]
+
+    if blocks.get("total_blocks", 0) > 0:
+        percentiles = blocks["percentiles_usd"]
+        lines += [
+            "## 5-hour block distribution",
+            "",
+            f"- Total non-gap blocks: {blocks['total_blocks']}",
+            f"- Mean block cost: ${blocks['mean_block_usd']:,.2f}",
+            f"- Percentiles - p50: ${percentiles['p50']:,.2f}, p75: ${percentiles['p75']:,.2f}, "
+            f"p90: ${percentiles['p90']:,.2f}, p95: ${percentiles['p95']:,.2f}, p99: ${percentiles['p99']:,.2f}",
+            f"- Max block cost: ${blocks['max_block_usd']:,.2f}",
+            "",
+            "| Bucket | Blocks |",
+            "| --- | ---: |",
+        ]
+        for bucket, count in blocks["buckets"].items():
+            lines.append(f"| {bucket} | {count} |")
+        lines.append("")
+
+    lines += [
+        "## Daily timeline",
+        "",
+        "| Date | Cost |",
+        "| --- | ---: |",
+    ]
+    for entry in summary["daily_timeline"]:
+        lines.append(f"| {entry['date']} | ${entry['cost_usd']:,.2f} |")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Fail fast on inverted windows. argparse already validated the format.
+    if args.until < args.since:
+        sys.exit(f"error: --until ({args.until}) is before --since ({args.since}).")
+
+    user = sanitize_user(args.user) if args.user else derive_user()
+    out_dir = Path(args.out_dir).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = resolve_ccusage(args.ccusage)
+    since_yyyymmdd = to_yyyymmdd(args.since)
+    until_yyyymmdd = to_yyyymmdd(args.until)
+    print(f"Running ccusage as: {' '.join(cmd)}", file=sys.stderr)
+    print(f"Window: {args.since} to {args.until} ({TIMEZONE})", file=sys.stderr)
+
+    common_extra = ["--since", since_yyyymmdd, "--until", until_yyyymmdd,
+                    "--mode", COST_MODE, "--timezone", TIMEZONE]
+    daily_data = run_ccusage(cmd, "daily", common_extra + ["--breakdown"])
+    blocks_data = run_ccusage(cmd, "blocks", common_extra)
+    ccusage_version = get_ccusage_version(cmd)
+
+    summary = summarize_daily(daily_data, args.since, args.until)
+    summary["block_stats"] = summarize_blocks(blocks_data)
+    summary["schema_version"] = SCHEMA_VERSION
+    summary["user"] = user
+    summary["generated"] = date.today().isoformat()
+    summary["ccusage_version"] = ccusage_version
+    summary["cost_mode"] = COST_MODE
+    summary["timezone"] = TIMEZONE
+
+    md_path = out_dir / f"{user}-summary.md"
+    json_path = out_dir / f"{user}-aggregate.json"
+    md_path.write_text(render_markdown(summary, user), encoding="utf-8")
+    json_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Wrote {md_path}")
+    print(f"Wrote {json_path}")
+    print(f"Total: ${summary['totals']['cost_usd']:,.2f} over {summary['window']['days']} "
+          f"days (monthly projection: ${summary['monthly_projection_usd']:,.2f})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_claude-usage-report.sh
+++ b/scripts/test_claude-usage-report.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Tests for scripts/claude-usage-report.py.
+#
+#   step 0: Python unit tests (logic in isolation — no ccusage required)
+#   step 1: --help loads (catches Python syntax / argparse errors)
+#   step 2: end-to-end run when ccusage / npx is available — both files
+#           appear with expected JSON keys and markdown headers
+#   step 3: negative case — inverted window exits non-zero
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/claude-usage-report.py"
+UNIT_TEST="$SCRIPT_DIR/test_claude_usage_report_unit.py"
+THROTTLE_UNIT_TEST="$SCRIPT_DIR/test_claude_throttle_audit_unit.py"
+
+# Probe python3 then python — Macs and some Linux distros only ship one.
+PYTHON="${PYTHON:-$(command -v python3 || command -v python || true)}"
+if [ -z "$PYTHON" ]; then
+    echo "FAIL: no python3 or python on PATH" >&2
+    exit 1
+fi
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "FAIL: script not found at $SCRIPT" >&2
+    exit 1
+fi
+
+# Step 0: unit tests — pure-Python, no external deps.
+if [ -f "$UNIT_TEST" ]; then
+    echo "step 0a: cost-report unit tests"
+    "$PYTHON" "$UNIT_TEST" -v 2>&1 | tail -3
+fi
+if [ -f "$THROTTLE_UNIT_TEST" ]; then
+    echo "step 0b: throttle-audit unit tests"
+    "$PYTHON" "$THROTTLE_UNIT_TEST" -v 2>&1 | tail -3
+fi
+
+# Step 1: help text loads.
+echo "step 1: --help loads"
+"$PYTHON" "$SCRIPT" --help >/dev/null
+
+# Step 2 & 3: only when ccusage or npx is available.
+if command -v ccusage >/dev/null 2>&1 || command -v npx >/dev/null 2>&1; then
+    echo "step 2: tight-window run produces both files"
+    # Use Python's tempfile so the path works for the Python script on Windows
+    # (Git Bash's `mktemp -d` returns `/tmp/...` which Python can't resolve).
+    TMPDIR_OUT="$("$PYTHON" -c 'import tempfile; print(tempfile.mkdtemp())')"
+    trap 'rm -rf "$TMPDIR_OUT"' EXIT
+    YESTERDAY="$("$PYTHON" -c 'from datetime import date,timedelta;print((date.today()-timedelta(days=1)).isoformat())')"
+    TODAY="$("$PYTHON" -c 'from datetime import date;print(date.today().isoformat())')"
+
+    "$PYTHON" "$SCRIPT" --since "$YESTERDAY" --until "$TODAY" \
+        --user smoketest --out-dir "$TMPDIR_OUT" >/dev/null
+
+    [ -f "$TMPDIR_OUT/smoketest-summary.md" ] || { echo "FAIL: summary missing" >&2; exit 1; }
+    [ -f "$TMPDIR_OUT/smoketest-aggregate.json" ] || { echo "FAIL: aggregate missing" >&2; exit 1; }
+
+    # Pass paths as argv to avoid Windows backslash-escape issues.
+    "$PYTHON" -c "
+import json, sys
+agg = json.load(open(sys.argv[1]))
+required = ['schema_version', 'user', 'window', 'totals', 'daily_stats',
+            'per_model_cost_usd', 'block_stats', 'ccusage_version',
+            'cost_mode', 'timezone']
+for key in required:
+    if key not in agg:
+        print('FAIL: aggregate missing key:', key, file=sys.stderr); sys.exit(1)
+md = open(sys.argv[2], encoding='utf-8').read()
+for header in ('## Summary', '## Per-model split', '## Token totals', '## Daily timeline'):
+    if header not in md:
+        print('FAIL: summary missing header:', header, file=sys.stderr); sys.exit(1)
+print('aggregate has all required keys; summary has all required headers')
+" "$TMPDIR_OUT/smoketest-aggregate.json" "$TMPDIR_OUT/smoketest-summary.md"
+
+    echo "step 3: inverted window exits non-zero"
+    if "$PYTHON" "$SCRIPT" --since "$TODAY" --until "$YESTERDAY" \
+        --user smoketest --out-dir "$TMPDIR_OUT" >/dev/null 2>&1; then
+        echo "FAIL: inverted window did not exit non-zero" >&2
+        exit 1
+    fi
+else
+    echo "step 2: skipped (no ccusage or npx on PATH)"
+    echo "step 3: skipped (depends on step 2)"
+fi
+
+echo "PASS"

--- a/scripts/test_claude_throttle_audit_unit.py
+++ b/scripts/test_claude_throttle_audit_unit.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/claude-throttle-audit.py.
+
+Functions tested in isolation: classify_event, extract_error_events, in_window,
+date_from_http_headers, summarize_events.
+
+Run directly:  python scripts/test_claude_throttle_audit_unit.py
+Or via the smoke test, which runs these alongside the cost-report tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+
+def _load_module():
+    """Load claude-throttle-audit.py despite the hyphen in the filename."""
+    script_path = Path(__file__).parent / "claude-throttle-audit.py"
+    spec = importlib.util.spec_from_file_location("claude_throttle_audit", script_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["claude_throttle_audit"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cta = _load_module()
+
+
+class ClassifyEventTests(unittest.TestCase):
+    def test_classify_event_extra_usage_text_wins_over_status(self):
+        # Arrange — 1M-context feature gate has status 429 but is not throttling
+        const_text = "API Error: Extra usage is required for 1M context - run /extra-usage"
+        const_status = 429
+        # Act
+        result = cta.classify_event(const_status, const_text)
+        # Assert
+        self.assertEqual(result, "extra_usage_required")
+
+    def test_classify_event_server_per_second_throttle_distinguished_from_plan_cap(self):
+        # Arrange — Anthropic explicitly disclaims plan cap in the error text
+        const_text = "API Error: Server is temporarily limiting requests (not your usage limit)"
+        const_status = 429
+        # Act
+        result = cta.classify_event(const_status, const_text)
+        # Assert
+        self.assertEqual(result, "server_per_second_throttle")
+
+    def test_classify_event_anthropic_overload_by_status(self):
+        # Arrange
+        const_status = 529
+        const_text = "API Error: 529 Overloaded"
+        # Act
+        result = cta.classify_event(const_status, const_text)
+        # Assert
+        self.assertEqual(result, "anthropic_overload")
+
+    def test_classify_event_anthropic_overload_by_text_when_status_missing(self):
+        # Arrange — text mentions overload but no status code attached
+        const_status = None
+        const_text = "API Error: Overloaded"
+        # Act
+        result = cta.classify_event(const_status, const_text)
+        # Assert
+        self.assertEqual(result, "anthropic_overload")
+
+    def test_classify_event_server_error_by_status(self):
+        # Arrange
+        const_status = 500
+        # Act
+        result = cta.classify_event(const_status, "")
+        # Assert
+        self.assertEqual(result, "server_error")
+
+    def test_classify_event_429_with_unrecognized_text_is_unspecified(self):
+        # Arrange — bare 429 without Anthropic's specific phrasings
+        const_status = 429
+        const_text = "Some other error"
+        # Act
+        result = cta.classify_event(const_status, const_text)
+        # Assert
+        self.assertEqual(result, "rate_limit_unspecified")
+
+    def test_classify_event_no_status_no_text_is_unclassified(self):
+        # Arrange
+        # Act / Assert
+        self.assertEqual(cta.classify_event(None, ""), "unclassified")
+        self.assertEqual(cta.classify_event(None, None), "unclassified")
+
+
+class DateFromHttpHeadersTests(unittest.TestCase):
+    def test_date_from_http_headers_valid_rfc7231_date_returns_iso(self):
+        # Arrange
+        const_headers = {"date": "Wed, 06 May 2026 15:24:50 GMT"}
+        const_expected = "2026-05-06T15:24:50Z"
+        # Act
+        result = cta.date_from_http_headers(const_headers)
+        # Assert
+        self.assertEqual(result, const_expected)
+
+    def test_date_from_http_headers_missing_date_returns_none(self):
+        # Arrange
+        const_headers: dict = {}
+        # Act
+        result = cta.date_from_http_headers(const_headers)
+        # Assert
+        self.assertIsNone(result)
+
+    def test_date_from_http_headers_malformed_date_returns_none(self):
+        # Arrange
+        const_headers = {"date": "not a real date"}
+        # Act
+        result = cta.date_from_http_headers(const_headers)
+        # Assert
+        self.assertIsNone(result)
+
+
+class ExtractErrorEventsTests(unittest.TestCase):
+    def test_extract_error_events_invalid_json_returns_empty(self):
+        # Arrange
+        const_line = "{not valid json"
+        # Act
+        result = cta.extract_error_events(const_line)
+        # Assert
+        self.assertEqual(result, [])
+
+    def test_extract_error_events_unrelated_line_returns_empty(self):
+        # Arrange — normal user message, no error indicators
+        obj = {"type": "user", "message": {"role": "user", "content": "hello"}}
+        # Act
+        result = cta.extract_error_events(json.dumps(obj))
+        # Assert
+        self.assertEqual(result, [])
+
+    def test_extract_error_events_system_api_error_extracted(self):
+        # Arrange — shape 1: system-level api_error log
+        const_status = 529
+        obj = {
+            "type": "system", "subtype": "api_error", "level": "error",
+            "error": {"status": const_status,
+                      "headers": {"date": "Wed, 06 May 2026 15:24:50 GMT"}},
+            "timestamp": "2026-05-06T15:24:50Z",
+        }
+        # Act
+        events = cta.extract_error_events(json.dumps(obj))
+        # Assert
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["kind"], "api_error_system")
+        self.assertEqual(events[0]["status"], const_status)
+        self.assertEqual(events[0]["category"], "anthropic_overload")
+
+    def test_extract_error_events_assistant_api_error_message_extracted(self):
+        # Arrange — shape 2: assistant-message-level error
+        const_status = 429
+        const_text = "API Error: Server is temporarily limiting requests (not your usage limit)"
+        obj = {
+            "type": "assistant",
+            "isApiErrorMessage": True,
+            "apiErrorStatus": const_status,
+            "error": "rate_limit",
+            "timestamp": "2026-04-15T10:30:00Z",
+            "message": {"content": [{"type": "text", "text": const_text}]},
+        }
+        # Act
+        events = cta.extract_error_events(json.dumps(obj))
+        # Assert
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["kind"], "api_error_message")
+        self.assertEqual(events[0]["status"], const_status)
+        self.assertEqual(events[0]["error_type"], "rate_limit")
+        self.assertEqual(events[0]["category"], "server_per_second_throttle")
+
+    def test_extract_error_events_extra_usage_gate_classified_separately(self):
+        # Arrange — same status (429) but feature-gate text, not throttling
+        obj = {
+            "type": "assistant",
+            "isApiErrorMessage": True,
+            "apiErrorStatus": 429,
+            "error": "rate_limit",
+            "timestamp": "2026-04-15T10:30:00Z",
+            "message": {"content": [{
+                "type": "text",
+                "text": "API Error: Extra usage is required for 1M context",
+            }]},
+        }
+        # Act
+        events = cta.extract_error_events(json.dumps(obj))
+        # Assert
+        self.assertEqual(events[0]["category"], "extra_usage_required")
+
+    def test_extract_error_events_malformed_error_field_skipped_safely(self):
+        # Arrange — defensive: error field is a string instead of dict on shape 1
+        obj = {"type": "system", "subtype": "api_error", "error": "rate_limit",
+               "timestamp": "2026-04-15T10:30:00Z"}
+        # Act — should not crash; shape 1 branch ignores non-dict error
+        events = cta.extract_error_events(json.dumps(obj))
+        # Assert
+        self.assertEqual(events, [])
+
+
+class InWindowTests(unittest.TestCase):
+    def test_in_window_inside_returns_true(self):
+        # Arrange
+        const_ts = "2026-04-15T10:00:00Z"
+        since_dt = datetime(2026, 4, 1)
+        until_dt = datetime(2026, 4, 30)
+        # Act / Assert
+        self.assertTrue(cta.in_window(const_ts, since_dt, until_dt))
+
+    def test_in_window_before_since_returns_false(self):
+        # Arrange
+        const_ts = "2026-03-31T23:00:00Z"
+        since_dt = datetime(2026, 4, 1)
+        until_dt = datetime(2026, 4, 30)
+        # Act / Assert
+        self.assertFalse(cta.in_window(const_ts, since_dt, until_dt))
+
+    def test_in_window_at_until_returns_false(self):
+        # Arrange — half-open interval, until is exclusive
+        const_ts = "2026-04-30T00:00:00Z"
+        since_dt = datetime(2026, 4, 1)
+        until_dt = datetime(2026, 4, 30)
+        # Act / Assert
+        self.assertFalse(cta.in_window(const_ts, since_dt, until_dt))
+
+    def test_in_window_missing_timestamp_returns_false(self):
+        # Arrange
+        since_dt = datetime(2026, 4, 1)
+        until_dt = datetime(2026, 4, 30)
+        # Act / Assert
+        self.assertFalse(cta.in_window(None, since_dt, until_dt))
+        self.assertFalse(cta.in_window("", since_dt, until_dt))
+
+    def test_in_window_malformed_timestamp_returns_false(self):
+        # Arrange
+        const_ts = "not a real timestamp"
+        since_dt = datetime(2026, 4, 1)
+        until_dt = datetime(2026, 4, 30)
+        # Act / Assert
+        self.assertFalse(cta.in_window(const_ts, since_dt, until_dt))
+
+
+class SummarizeEventsTests(unittest.TestCase):
+    def test_summarize_events_empty_returns_zero_totals(self):
+        # Arrange
+        # Act
+        result = cta.summarize_events([], "2026-04-01", "2026-04-30")
+        # Assert
+        self.assertEqual(result["total_events"], 0)
+        self.assertEqual(result["by_kind"], {})
+        self.assertEqual(result["by_status"], {})
+        self.assertEqual(result["by_category"], {})
+
+    def test_summarize_events_groups_by_category_and_month(self):
+        # Arrange
+        events = [
+            {"kind": "api_error_message", "status": 429,
+             "category": "server_per_second_throttle",
+             "timestamp": "2026-04-15T10:00:00Z"},
+            {"kind": "api_error_message", "status": 429,
+             "category": "server_per_second_throttle",
+             "timestamp": "2026-05-02T11:00:00Z"},
+            {"kind": "api_error_system", "status": 529,
+             "category": "anthropic_overload",
+             "timestamp": "2026-05-06T15:00:00Z"},
+        ]
+        # Act
+        result = cta.summarize_events(events, "2026-04-01", "2026-05-31")
+        # Assert
+        self.assertEqual(result["total_events"], 3)
+        self.assertEqual(result["by_category"]["server_per_second_throttle"], 2)
+        self.assertEqual(result["by_category"]["anthropic_overload"], 1)
+        self.assertEqual(result["by_month"]["2026-04"]["server_per_second_throttle"], 1)
+        self.assertEqual(result["by_month"]["2026-05"]["server_per_second_throttle"], 1)
+        self.assertEqual(result["by_month"]["2026-05"]["anthropic_overload"], 1)
+
+    def test_summarize_events_timeline_sorted_by_timestamp(self):
+        # Arrange — out of order
+        events = [
+            {"kind": "api_error_message", "status": 529, "category": "anthropic_overload",
+             "timestamp": "2026-05-06T15:00:00Z"},
+            {"kind": "api_error_message", "status": 429,
+             "category": "server_per_second_throttle",
+             "timestamp": "2026-04-15T10:00:00Z"},
+        ]
+        # Act
+        result = cta.summarize_events(events, "2026-04-01", "2026-05-31")
+        # Assert
+        timestamps = [e["timestamp"] for e in result["timeline"]]
+        self.assertEqual(timestamps, sorted(timestamps))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_claude_usage_report_unit.py
+++ b/scripts/test_claude_usage_report_unit.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/claude-usage-report.py.
+
+Functions tested in isolation: percentile, bucketize, summarize_daily,
+summarize_blocks, to_yyyymmdd, parse_iso_date, sanitize_user, resolve_ccusage,
+get_ccusage_version.
+
+Run directly:  python scripts/test_claude_usage_report_unit.py
+Or via the smoke test, which runs these as step 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+def _load_module():
+    """Load claude-usage-report.py despite the hyphen in the filename."""
+    script_path = Path(__file__).parent / "claude-usage-report.py"
+    spec = importlib.util.spec_from_file_location("claude_usage_report", script_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["claude_usage_report"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cur = _load_module()
+
+
+class PercentileTests(unittest.TestCase):
+    def test_percentile_empty_list_returns_zero(self):
+        # Arrange
+        values: list[float] = []
+        const_pct = 50.0
+        # Act
+        result = cur.percentile(values, const_pct)
+        # Assert
+        self.assertEqual(result, 0.0)
+
+    def test_percentile_single_element_returns_that_element_for_any_pct(self):
+        # Arrange
+        const_only = 42.0
+        values = [const_only]
+        # Act / Assert
+        self.assertEqual(cur.percentile(values, 0), const_only)
+        self.assertEqual(cur.percentile(values, 50), const_only)
+        self.assertEqual(cur.percentile(values, 100), const_only)
+
+    def test_percentile_ten_sorted_p50_returns_linear_median(self):
+        # Arrange — n=10, k=(10-1)*0.5=4.5 → interpolate between sorted[4]=5 and sorted[5]=6
+        values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        const_expected = 5.5
+        # Act
+        result = cur.percentile(values, 50)
+        # Assert
+        self.assertAlmostEqual(result, const_expected)
+
+    def test_percentile_p0_and_p100_return_min_and_max(self):
+        # Arrange
+        values = [3, 1, 4, 1, 5, 9, 2, 6]
+        const_expected_min = 1
+        const_expected_max = 9
+        # Act / Assert
+        self.assertEqual(cur.percentile(values, 0), const_expected_min)
+        self.assertEqual(cur.percentile(values, 100), const_expected_max)
+
+    def test_percentile_unsorted_input_produces_sorted_answer(self):
+        # Arrange — sorted = [1,3,5,8,10], k=(5-1)*0.5=2.0, sorted[2]=5
+        values = [10, 1, 5, 3, 8]
+        const_expected = 5
+        # Act
+        result = cur.percentile(values, 50)
+        # Assert
+        self.assertEqual(result, const_expected)
+
+
+class BucketizeTests(unittest.TestCase):
+    def test_bucketize_empty_list_all_zero_counts(self):
+        # Arrange / Act
+        result = cur.bucketize([])
+        # Assert
+        self.assertTrue(all(count == 0 for count in result.values()))
+        self.assertEqual(sum(result.values()), 0)
+
+    def test_bucketize_boundary_values_land_in_expected_half_open_bucket(self):
+        # Arrange — half-open intervals: [0,1) [1,5) [5,10) ... [500,inf)
+        const_zero = 0.0
+        const_one = 1.0
+        const_five = 5.0
+        const_500 = 500.0
+        # Act
+        result = cur.bucketize([const_zero, const_one, const_five, const_500])
+        # Assert
+        self.assertEqual(result["<$1"], 1)
+        self.assertEqual(result["$1-5"], 1)
+        self.assertEqual(result["$5-10"], 1)
+        self.assertEqual(result["$500+"], 1)
+
+    def test_bucketize_large_value_lands_in_top_bucket(self):
+        # Arrange
+        const_huge = 12345.0
+        # Act
+        result = cur.bucketize([const_huge])
+        # Assert
+        self.assertEqual(result["$500+"], 1)
+
+    def test_bucketize_negative_value_clamped_to_bottom_bucket(self):
+        # Arrange — defensive: ccusage shouldn't produce negatives
+        const_negative = -5.0
+        # Act
+        result = cur.bucketize([const_negative])
+        # Assert — clamped to 0, bucket totals still sum to input count
+        self.assertEqual(result["<$1"], 1)
+        self.assertEqual(sum(result.values()), 1)
+
+    def test_bucketize_bucket_totals_equal_input_count(self):
+        # Arrange
+        costs = [0.5, 2.5, 7.0, 100.0, 250.0, 999.0]
+        # Act
+        result = cur.bucketize(costs)
+        # Assert
+        self.assertEqual(sum(result.values()), len(costs))
+
+
+class ToYyyymmddTests(unittest.TestCase):
+    def test_to_yyyymmdd_valid_date_returns_compact_form(self):
+        # Arrange
+        const_iso = "2026-05-06"
+        const_expected = "20260506"
+        # Act
+        result = cur.to_yyyymmdd(const_iso)
+        # Assert
+        self.assertEqual(result, const_expected)
+
+    def test_to_yyyymmdd_invalid_format_raises_value_error(self):
+        # Arrange
+        const_bad = "2026/05/06"
+        # Act / Assert
+        with self.assertRaises(ValueError):
+            cur.to_yyyymmdd(const_bad)
+
+
+class ParseIsoDateTests(unittest.TestCase):
+    def test_parse_iso_date_valid_returns_string_unchanged(self):
+        # Arrange
+        const_iso = "2026-05-06"
+        # Act
+        result = cur.parse_iso_date(const_iso)
+        # Assert
+        self.assertEqual(result, const_iso)
+
+    def test_parse_iso_date_invalid_format_raises_argparse_type_error(self):
+        # Arrange
+        const_bad = "may-6-2026"
+        # Act / Assert
+        with self.assertRaises(argparse.ArgumentTypeError):
+            cur.parse_iso_date(const_bad)
+
+    def test_parse_iso_date_invalid_calendar_date_raises_argparse_type_error(self):
+        # Arrange — Feb 30 is a real format but not a real date
+        const_bad = "2026-02-30"
+        # Act / Assert
+        with self.assertRaises(argparse.ArgumentTypeError):
+            cur.parse_iso_date(const_bad)
+
+
+class SanitizeUserTests(unittest.TestCase):
+    def test_sanitize_user_path_separators_replaced(self):
+        # Arrange
+        const_traversal = "../foo/bar"
+        # Act
+        result = cur.sanitize_user(const_traversal)
+        # Assert — no slashes, no dots, no parent-traversal substring
+        self.assertNotIn("/", result)
+        self.assertNotIn("\\", result)
+        self.assertNotIn(".", result)
+        self.assertNotIn("..", result)
+
+    def test_sanitize_user_spaces_and_case_normalized(self):
+        # Arrange
+        const_input = "Tim Zander"
+        const_expected = "tim_zander"
+        # Act
+        result = cur.sanitize_user(const_input)
+        # Assert
+        self.assertEqual(result, const_expected)
+
+    def test_sanitize_user_only_unsafe_chars_falls_back_to_default(self):
+        # Arrange — strips to nothing, should default to "user"
+        const_input = "../"
+        const_expected = "user"
+        # Act
+        result = cur.sanitize_user(const_input)
+        # Assert
+        self.assertEqual(result, const_expected)
+
+    def test_sanitize_user_already_safe_passes_through(self):
+        # Arrange
+        const_input = "tzander"
+        # Act
+        result = cur.sanitize_user(const_input)
+        # Assert
+        self.assertEqual(result, const_input)
+
+
+class ResolveCcusageTests(unittest.TestCase):
+    def test_resolve_ccusage_empty_override_exits_with_error(self):
+        # Arrange
+        const_empty = ""
+        # Act / Assert
+        with self.assertRaises(SystemExit):
+            cur.resolve_ccusage(const_empty)
+
+    def test_resolve_ccusage_whitespace_override_exits_with_error(self):
+        # Arrange
+        const_whitespace = "   "
+        # Act / Assert
+        with self.assertRaises(SystemExit):
+            cur.resolve_ccusage(const_whitespace)
+
+
+class SummarizeDailyTests(unittest.TestCase):
+    def test_summarize_daily_empty_data_returns_zero_valued_summary(self):
+        # Arrange
+        const_data: dict = {"daily": [], "totals": {}}
+        const_since = "2026-04-01"
+        const_until = "2026-04-30"
+        const_expected_days = 30
+        # Act
+        result = cur.summarize_daily(const_data, const_since, const_until)
+        # Assert
+        self.assertEqual(result["totals"]["cost_usd"], 0.0)
+        self.assertEqual(result["active_days"], 0)
+        self.assertEqual(result["window"]["days"], const_expected_days)
+        self.assertEqual(result["per_model_cost_usd"], {})
+
+    def test_summarize_daily_single_day_produces_correct_aggregate(self):
+        # Arrange
+        const_cost = 100.0
+        const_opus_cost = 90.0
+        const_haiku_cost = 10.0
+        const_data = {
+            "daily": [{
+                "date": "2026-04-01",
+                "totalCost": const_cost,
+                "modelBreakdowns": [
+                    {"modelName": "claude-opus-4-7", "cost": const_opus_cost},
+                    {"modelName": "claude-haiku-4-5", "cost": const_haiku_cost},
+                ],
+            }],
+            "totals": {
+                "totalCost": const_cost,
+                "inputTokens": 1000, "outputTokens": 500,
+                "cacheCreationTokens": 100, "cacheReadTokens": 5000,
+            },
+        }
+        # Act
+        result = cur.summarize_daily(const_data, "2026-04-01", "2026-04-01")
+        # Assert
+        self.assertEqual(result["totals"]["cost_usd"], const_cost)
+        self.assertEqual(result["active_days"], 1)
+        self.assertEqual(result["window"]["days"], 1)
+        self.assertEqual(result["per_model_cost_usd"]["claude-opus-4-7"], const_opus_cost)
+        self.assertEqual(result["per_model_cost_usd"]["claude-haiku-4-5"], const_haiku_cost)
+        self.assertEqual(result["daily_timeline"],
+                         [{"date": "2026-04-01", "cost_usd": const_cost}])
+
+    def test_summarize_daily_null_cost_fields_treated_as_zero(self):
+        # Arrange — defensive against schema drift; ccusage today doesn't emit nulls.
+        const_data = {
+            "daily": [{"date": "2026-04-01", "totalCost": None, "modelBreakdowns": None}],
+            "totals": {"totalCost": None, "inputTokens": None},
+        }
+        # Act
+        result = cur.summarize_daily(const_data, "2026-04-01", "2026-04-01")
+        # Assert — no crash; nulls treated as zero
+        self.assertEqual(result["totals"]["cost_usd"], 0.0)
+        self.assertEqual(result["totals"]["input_tokens"], 0)
+        self.assertEqual(result["daily_stats"]["min"], 0.0)
+
+    def test_summarize_daily_aggregates_same_model_across_days(self):
+        # Arrange — same model reported on two days; per_model_cost_usd should sum them
+        const_data = {
+            "daily": [
+                {"date": "2026-04-01", "totalCost": 50.0,
+                 "modelBreakdowns": [{"modelName": "claude-opus-4-7", "cost": 50.0}]},
+                {"date": "2026-04-02", "totalCost": 30.0,
+                 "modelBreakdowns": [{"modelName": "claude-opus-4-7", "cost": 30.0}]},
+            ],
+            "totals": {"totalCost": 80.0},
+        }
+        const_expected_opus_total = 80.0
+        # Act
+        result = cur.summarize_daily(const_data, "2026-04-01", "2026-04-02")
+        # Assert
+        self.assertEqual(result["per_model_cost_usd"]["claude-opus-4-7"],
+                         const_expected_opus_total)
+
+    def test_summarize_daily_monthly_projection_is_avg_times_thirty(self):
+        # Arrange — 5-day window, $50 total → avg=$10/day → projection=$300
+        const_data = {
+            "daily": [{"date": "2026-04-01", "totalCost": 50.0, "modelBreakdowns": []}],
+            "totals": {"totalCost": 50.0},
+        }
+        const_expected_projection = 300.0
+        # Act — 5-day window: 04-01 to 04-05 inclusive
+        result = cur.summarize_daily(const_data, "2026-04-01", "2026-04-05")
+        # Assert
+        self.assertEqual(result["window"]["days"], 5)
+        self.assertEqual(result["monthly_projection_usd"], const_expected_projection)
+
+
+class SummarizeBlocksTests(unittest.TestCase):
+    def test_summarize_blocks_empty_blocks_returns_zero_valued_summary(self):
+        # Arrange
+        const_data = {"blocks": []}
+        # Act
+        result = cur.summarize_blocks(const_data)
+        # Assert
+        self.assertEqual(result["total_blocks"], 0)
+        self.assertEqual(result["max_block_usd"], 0.0)
+        self.assertEqual(result["mean_block_usd"], 0.0)
+
+    def test_summarize_blocks_gap_blocks_filtered_out(self):
+        # Arrange
+        const_real_low = 10.0
+        const_gap = 20.0
+        const_real_high = 30.0
+        const_data = {"blocks": [
+            {"costUSD": const_real_low, "isGap": False},
+            {"costUSD": const_gap, "isGap": True},
+            {"costUSD": const_real_high, "isGap": False},
+        ]}
+        # Act
+        result = cur.summarize_blocks(const_data)
+        # Assert
+        self.assertEqual(result["total_blocks"], 2)
+        self.assertEqual(result["max_block_usd"], const_real_high)
+
+    def test_summarize_blocks_single_block_all_percentiles_equal(self):
+        # Arrange
+        const_cost = 50.0
+        const_data = {"blocks": [{"costUSD": const_cost, "isGap": False}]}
+        # Act
+        result = cur.summarize_blocks(const_data)
+        # Assert
+        for key in ("p50", "p75", "p90", "p95", "p99"):
+            self.assertEqual(result["percentiles_usd"][key], const_cost)
+
+    def test_summarize_blocks_null_cost_treated_as_zero(self):
+        # Arrange
+        const_data = {"blocks": [{"costUSD": None, "isGap": False}]}
+        # Act
+        result = cur.summarize_blocks(const_data)
+        # Assert — no crash; null becomes 0, lands in <$1 bucket
+        self.assertEqual(result["total_blocks"], 1)
+        self.assertEqual(result["buckets"]["<$1"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `scripts/claude-usage-report.py` — wraps `ccusage daily`/`ccusage blocks` to emit per-developer `<user>-summary.md` and `<user>-aggregate.json` (no transcript content). Useful for team-subscription cost analysis.
- Add `scripts/claude-throttle-audit.py` — companion diagnostic surfacing server-side errors and feature gates from jsonl transcripts. Documented limitation: cannot detect weekly/5-hour plan-cap hits (those go through Claude Code UI without writing to the session log).
- Add `docs/claude-usage-howto.md` — team-member guide for running the cost report.
- Add 54 unit tests (`scripts/test_claude_usage_report_unit.py`, `scripts/test_claude_throttle_audit_unit.py`) plus a bash smoke test (`scripts/test_claude-usage-report.sh`) covering: percentile interpolation, bucket boundary classification, summarization, error-event extraction and categorization, end-to-end happy path, output content validation, and inverted-window rejection.

All ccusage calls use `--timezone UTC` and `--mode calculate` so cross-seat aggregates are comparable regardless of where the developer ran the script.

## Test plan

- [ ] `bash scripts/test_claude-usage-report.sh` runs from repo root and prints `PASS`
- [ ] `python scripts/claude-usage-report.py --help` shows usage info without errors
- [ ] `python scripts/claude-usage-report.py --out-dir /tmp/test` produces both `<user>-summary.md` and `<user>-aggregate.json`
- [ ] Aggregate JSON contains expected keys: `schema_version`, `user`, `window`, `totals`, `daily_stats`, `per_model_cost_usd`, `block_stats`, `ccusage_version`, `cost_mode`, `timezone`
- [ ] Summary markdown contains expected sections: Summary, Per-model split, Token totals, Daily timeline (and 5-hour block distribution when blocks exist)
- [ ] Inverted window (`--until` before `--since`) exits non-zero with a clear error
- [ ] `python scripts/claude-throttle-audit.py --help` shows usage info, including the limitation note about plan-cap hits