### PR TITLE
Add per-skill cost attribution report tooling

### DIFF
--- a/scripts/claude-skill-attribution.py
+++ b/scripts/claude-skill-attribution.py
@@ -38,7 +38,7 @@ from collections import defaultdict
 from datetime import date, datetime, timedelta
 from pathlib import Path
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2  # v2 added skill_efficiency (per-invocation context bloat metrics)
 SAFE_USER_RE = re.compile(r"[^a-z0-9_-]")
 DEFAULT_TOP_N = 20
 # ccusage doesn't read agent-*.jsonl files, so our totals run modestly higher
@@ -338,6 +338,123 @@ def walk_subagent_file(path: Path, since: str, until: str,
     return records
 
 
+def cache_read_rate(model_canon: str) -> float:
+    """USD per token for cache_read at this model's rate, 0 if unknown."""
+    if model_canon not in PRICES:
+        return 0.0
+    return PRICES[model_canon]["cache_read"] / 1_000_000
+
+
+def walk_main_session_invocations(path: Path, since: str, until: str,
+                                  unknown_models: set[str]) -> list[dict]:
+    """Emit one record per main-thread Skill invocation.
+
+    Captures the context size at the moment the skill was invoked (everything
+    the skill had to inherit) and the cost of the entire skill window. Lets us
+    flag skills that are repeatedly invoked deep into bloated sessions.
+
+    Subagents start fresh, so they're not the question — only main-session
+    JSONLs feed this walker.
+    """
+    records: list[dict] = []
+    active: dict | None = None  # in-flight invocation accumulator
+
+    def close(active_state: dict | None) -> None:
+        if active_state is None:
+            return
+        records.append(active_state)
+
+    try:
+        with path.open("r", encoding="utf-8") as fp:
+            for line in fp:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                etype = entry.get("type")
+                if etype == "user" and is_real_user_turn(entry):
+                    close(active)
+                    active = None
+                    continue
+                if etype != "assistant":
+                    continue
+                msg = entry.get("message") or {}
+                usage = msg.get("usage") or {}
+                model_canon = canonicalize_model(msg.get("model") or "")
+                # When a Skill tool_use appears, close any prior window and open a new one.
+                # The invocation turn itself is included in the new window.
+                for tu in extract_tool_uses(entry):
+                    if tu.get("name") == "Skill":
+                        skill = (tu.get("input") or {}).get("skill")
+                        if skill:
+                            close(active)
+                            if not in_window(entry.get("timestamp", ""), since, until):
+                                active = None
+                                continue
+                            active = {
+                                "skill": skill,
+                                "timestamp": entry.get("timestamp"),
+                                "session_id": entry.get("sessionId"),
+                                "git_branch": entry.get("gitBranch"),
+                                "model_at_invoke": model_canon,
+                                "ctx_at_invoke": context_size(usage),
+                                "n_turns": 0,
+                                "window_cost_usd": 0.0,
+                                "wasted_cache_read_lb_usd": 0.0,
+                            }
+                if active is not None:
+                    active["n_turns"] += 1
+                    active["window_cost_usd"] += turn_cost_usd(model_canon, usage, unknown_models)
+                    # Floor: every turn re-reads at least the inherited context.
+                    active["wasted_cache_read_lb_usd"] += (
+                        active["ctx_at_invoke"] * cache_read_rate(model_canon))
+            close(active)
+    except OSError:
+        pass
+    return records
+
+
+def collect_invocations(projects_dir: Path, since: str, until: str,
+                        unknown_models: set[str]) -> list[dict]:
+    """Walk every main-session JSONL and collect Skill invocation records."""
+    invocations: list[dict] = []
+    for jsonl in projects_dir.rglob("*.jsonl"):
+        if jsonl.name.startswith("agent-"):
+            continue
+        invocations.extend(
+            walk_main_session_invocations(jsonl, since, until, unknown_models))
+    return invocations
+
+
+def aggregate_skill_efficiency(invocations: list[dict]) -> list[dict]:
+    """Per-skill: how often is it invoked into a bloated context, and what does
+    that cost. Sorted by total wasted-spend descending so the worst offenders
+    surface first."""
+    by_skill: dict[str, list[dict]] = defaultdict(list)
+    for inv in invocations:
+        by_skill[inv["skill"]].append(inv)
+    rows = []
+    for skill, items in by_skill.items():
+        n = len(items)
+        total_cost = sum(i["window_cost_usd"] for i in items)
+        total_wasted = sum(i["wasted_cache_read_lb_usd"] for i in items)
+        rows.append({
+            "skill": skill,
+            "invocations": n,
+            "mean_ctx_at_invoke": round(sum(i["ctx_at_invoke"] for i in items) / n),
+            "p95_ctx_at_invoke": round(percentile(
+                [i["ctx_at_invoke"] for i in items], 95)),
+            "max_ctx_at_invoke": max(i["ctx_at_invoke"] for i in items),
+            "mean_turns_per_invocation": round(
+                sum(i["n_turns"] for i in items) / n, 1),
+            "total_window_cost_usd": round(total_cost, 2),
+            "wasted_cache_read_lb_usd": round(total_wasted, 2),
+            "wasted_pct": round((total_wasted / total_cost) * 100, 1) if total_cost else 0.0,
+        })
+    rows.sort(key=lambda r: -r["wasted_cache_read_lb_usd"])
+    return rows
+
+
 def collect_all(projects_dir: Path, since: str, until: str,
                 unknown_models: set[str]) -> list[dict]:
     """Walk every JSONL under projects_dir, classifying main vs subagent by name.
@@ -555,6 +672,31 @@ def render_markdown(report: dict, top_n: int) -> str:
             f"{row['p95_context_tokens']:,} | {share_str} |"
         )
 
+    eff_rows = report.get("skill_efficiency") or []
+    if eff_rows:
+        lines += [
+            "",
+            "## Skill context efficiency (main-thread invocations)",
+            "",
+            "_How bloated was the conversation when each skill was invoked?_ "
+            "`wasted (lb)` is a lower bound: every turn in the skill window "
+            "re-reads at least the inherited context, billed at cache_read rates. "
+            "High % means the skill is repeatedly invoked into a session that's "
+            "already large and could likely run cheaper after `/clear`.",
+            "",
+            "| Skill | Inv | Mean ctx@invoke | p95 | Turns/inv | Cost | Wasted (lb) | % |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+        for r in eff_rows:
+            lines.append(
+                f"| `{r['skill']}` | {r['invocations']:,} | "
+                f"{r['mean_ctx_at_invoke']:,} | {r['p95_ctx_at_invoke']:,} | "
+                f"{r['mean_turns_per_invocation']} | "
+                f"${r['total_window_cost_usd']:,.2f} | "
+                f"${r['wasted_cache_read_lb_usd']:,.2f} | "
+                f"{r['wasted_pct']}% |"
+            )
+
     lines += ["", "## Per-subagent_type spend (sidechain only)", "",
               "| Agent type | Cost | Turns | Mean $/turn |",
               "| --- | ---: | ---: | ---: |"]
@@ -601,6 +743,9 @@ def main() -> int:
     records = collect_all(projects_dir, args.since, args.until, unknown_models)
     print(f"Collected {len(records):,} assistant turns in window.", file=sys.stderr)
 
+    invocations = collect_invocations(projects_dir, args.since, args.until, unknown_models)
+    print(f"Collected {len(invocations):,} main-thread skill invocations.", file=sys.stderr)
+
     total_cost = sum(r["cost_usd"] for r in records)
     window_days = (datetime.strptime(args.until, "%Y-%m-%d")
                    - datetime.strptime(args.since, "%Y-%m-%d")).days + 1
@@ -615,6 +760,7 @@ def main() -> int:
         "unknown_models": sorted(unknown_models),
         "main_vs_sidechain": main_vs_sidechain(records),
         "per_skill": aggregate_per_skill(records),
+        "skill_efficiency": aggregate_skill_efficiency(invocations),
         "per_agent_type": aggregate_per_agent_type(records),
         "top_turns": top_turns(records, args.top),
     }

--- a/scripts/claude-skill-attribution.py
+++ b/scripts/claude-skill-attribution.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+"""Claude Code per-skill / per-agent cost attribution.
+
+Reads ~/.claude/projects/**/*.jsonl directly (does NOT wrap ccusage), groups
+assistant turns by the active skill and main-vs-sidechain context, and applies
+per-model pricing locally. Reconciles total spend against ccusage at the end so
+drift in hardcoded rates is visible.
+
+Outputs:
+  <user>-attribution.md      ranked tables + top-N expensive turns
+  <user>-attribution.json    raw aggregates (no transcript text)
+
+Skill attribution model:
+  Main-thread turns: a skill is active from the assistant turn that emits a
+  Skill tool_use through the next user message. Nested invocations replace the
+  active skill (innermost wins).
+
+  Subagent turns: read directly from the `attributionSkill` and
+  `attributionAgent` fields the harness already records on agent-*.jsonl turns.
+
+Usage:
+  python scripts/claude-skill-attribution.py [--since YYYY-MM-DD] [--until YYYY-MM-DD]
+                                             [--user NAME] [--out-dir PATH]
+                                             [--top N] [--ccusage 'CMD ARGS']
+                                             [--no-reconcile]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+SAFE_USER_RE = re.compile(r"[^a-z0-9_-]")
+DEFAULT_TOP_N = 20
+# ccusage doesn't read agent-*.jsonl files, so our totals run modestly higher
+# than ccusage's by the subagent share. Empirically ~5-15% on heavy-subagent
+# usage. Beyond this threshold something else is wrong (stale rates, new model
+# tier, etc.) and the user should investigate.
+RECONCILE_WARN_PCT = 20.0
+
+# Per-1M-token rates in USD, sourced from LiteLLM's model_prices_and_context_window.json
+# (the same dataset ccusage uses). Last verified 2026-05-07. The reconcile step against
+# ccusage surfaces drift if Anthropic changes pricing or new models appear.
+#
+# Note: Opus 4 / 4.1 stayed at $15 input / $75 output, but Opus 4.5+ dropped to
+# $5 input / $25 output. Treating them all the same was a 3x overcount.
+#
+# Keys are CANONICAL model names (date suffixes stripped — see canonicalize_model).
+PRICES: dict[str, dict[str, float]] = {
+    # Opus 4.5+ tier
+    "claude-opus-4-7": {
+        "input": 5.0, "output": 25.0,
+        "cache_5m": 6.25, "cache_1h": 10.0, "cache_read": 0.50,
+    },
+    "claude-opus-4-6": {
+        "input": 5.0, "output": 25.0,
+        "cache_5m": 6.25, "cache_1h": 10.0, "cache_read": 0.50,
+    },
+    "claude-opus-4-5": {
+        "input": 5.0, "output": 25.0,
+        "cache_5m": 6.25, "cache_1h": 10.0, "cache_read": 0.50,
+    },
+    # Older Opus 4.x tier
+    "claude-opus-4-1": {
+        "input": 15.0, "output": 75.0,
+        "cache_5m": 18.75, "cache_1h": 30.0, "cache_read": 1.50,
+    },
+    "claude-opus-4": {
+        "input": 15.0, "output": 75.0,
+        "cache_5m": 18.75, "cache_1h": 30.0, "cache_read": 1.50,
+    },
+    # Sonnet 4.x tier (5/6 share rates)
+    "claude-sonnet-4-6": {
+        "input": 3.0, "output": 15.0,
+        "cache_5m": 3.75, "cache_1h": 6.0, "cache_read": 0.30,
+    },
+    "claude-sonnet-4-5": {
+        "input": 3.0, "output": 15.0,
+        "cache_5m": 3.75, "cache_1h": 6.0, "cache_read": 0.30,
+    },
+    "claude-sonnet-4": {
+        "input": 3.0, "output": 15.0,
+        "cache_5m": 3.75, "cache_1h": 6.0, "cache_read": 0.30,
+    },
+    # Haiku 4.5
+    "claude-haiku-4-5": {
+        "input": 1.0, "output": 5.0,
+        "cache_5m": 1.25, "cache_1h": 2.0, "cache_read": 0.10,
+    },
+}
+
+DATE_SUFFIX_RE = re.compile(r"-\d{8}$")
+
+
+def canonicalize_model(model: str) -> str:
+    """Strip trailing -YYYYMMDD date suffix that some model IDs carry.
+
+    e.g. claude-haiku-4-5-20251001 → claude-haiku-4-5.
+    Returns the input unchanged if no suffix matches; unknown models are
+    surfaced as-is so the unknown-model warning fires later.
+    """
+    return DATE_SUFFIX_RE.sub("", model or "")
+
+
+def parse_iso_date(value: str) -> str:
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"invalid date {value!r}: expected YYYY-MM-DD"
+        )
+    return value
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    default_since = (date.today() - timedelta(days=60)).isoformat()
+    default_until = date.today().isoformat()
+    parser.add_argument("--since", default=default_since, type=parse_iso_date,
+                        help="Window start (YYYY-MM-DD, UTC). Default: 60 days ago.")
+    parser.add_argument("--until", default=default_until, type=parse_iso_date,
+                        help="Window end (YYYY-MM-DD, UTC). Default: today.")
+    parser.add_argument("--user", default=None,
+                        help="Output filename prefix (default: $USER / $USERNAME, sanitized).")
+    parser.add_argument("--out-dir", default=".", help="Output directory.")
+    parser.add_argument("--top", default=DEFAULT_TOP_N, type=int,
+                        help=f"Top-N most expensive turns to list. Default: {DEFAULT_TOP_N}.")
+    parser.add_argument("--projects-dir", default=None,
+                        help="Override transcripts root (default: ~/.claude/projects).")
+    parser.add_argument("--ccusage", default=None,
+                        help="Override ccusage command for the reconcile step.")
+    parser.add_argument("--no-reconcile", action="store_true",
+                        help="Skip the ccusage reconcile cross-check.")
+    return parser.parse_args()
+
+
+def sanitize_user(value: str) -> str:
+    cleaned = SAFE_USER_RE.sub("_", value.strip().lower().replace(" ", "_"))
+    cleaned = cleaned.strip("_")
+    return cleaned or "user"
+
+
+def derive_user() -> str:
+    for var in ("USER", "USERNAME"):
+        value = os.environ.get(var)
+        if value:
+            return sanitize_user(value)
+    return "user"
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    sorted_values = sorted(values)
+    k = (len(sorted_values) - 1) * pct / 100.0
+    floor_index = int(k)
+    ceil_index = min(floor_index + 1, len(sorted_values) - 1)
+    fraction = k - floor_index
+    return sorted_values[floor_index] + (sorted_values[ceil_index] - sorted_values[floor_index]) * fraction
+
+
+def turn_cost_usd(model_canon: str, usage: dict, unknown_models: set[str]) -> float:
+    """Compute per-turn cost using the cache-aware token breakdown.
+
+    Returns 0.0 for unknown models and records them so the report surfaces
+    pricing gaps. ccusage's reconcile step is the safety net.
+    """
+    if model_canon not in PRICES:
+        unknown_models.add(model_canon)
+        return 0.0
+    p = PRICES[model_canon]
+    cache_creation = usage.get("cache_creation") or {}
+    ephem_5m = cache_creation.get("ephemeral_5m_input_tokens") or 0
+    ephem_1h = cache_creation.get("ephemeral_1h_input_tokens") or 0
+    # cacheCreationInputTokens is the total of 5m + 1h. If the breakdown is
+    # missing (older transcripts), bill the whole thing at the 5m rate — this
+    # is what ccusage does and what older Anthropic API responses imply.
+    total_creation = usage.get("cache_creation_input_tokens") or 0
+    if not (ephem_5m or ephem_1h) and total_creation:
+        ephem_5m = total_creation
+    input_t = usage.get("input_tokens") or 0
+    cache_read = usage.get("cache_read_input_tokens") or 0
+    output_t = usage.get("output_tokens") or 0
+    return (
+        input_t * p["input"]
+        + output_t * p["output"]
+        + ephem_5m * p["cache_5m"]
+        + ephem_1h * p["cache_1h"]
+        + cache_read * p["cache_read"]
+    ) / 1_000_000
+
+
+def context_size(usage: dict) -> int:
+    """Total tokens-in-prompt for this turn (input side only — excludes output).
+
+    This is what fills the context window; useful for spotting skills that
+    bloat prompts.
+    """
+    return ((usage.get("input_tokens") or 0)
+            + (usage.get("cache_read_input_tokens") or 0)
+            + (usage.get("cache_creation_input_tokens") or 0))
+
+
+def in_window(timestamp: str, since: str, until: str) -> bool:
+    """until is inclusive: the whole calendar day in UTC."""
+    if not timestamp:
+        return False
+    # ISO timestamps end in 'Z'; date prefix is YYYY-MM-DD.
+    day = timestamp[:10]
+    return since <= day <= until
+
+
+def is_real_user_turn(entry: dict) -> bool:
+    """A user turn that resets the skill window (not a tool_result, not meta).
+
+    Tool results come back as user-role messages too, but they don't end the
+    skill — only a true user prompt does.
+    """
+    if entry.get("type") != "user" or entry.get("isMeta"):
+        return False
+    msg = entry.get("message") or {}
+    content = msg.get("content")
+    if isinstance(content, list):
+        # If every block is a tool_result, this is a tool turn, not user input.
+        if all((c.get("type") == "tool_result") for c in content if isinstance(c, dict)):
+            return False
+    return True
+
+
+def extract_tool_uses(entry: dict) -> list[dict]:
+    msg = entry.get("message") or {}
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return []
+    return [c for c in content if isinstance(c, dict) and c.get("type") == "tool_use"]
+
+
+def walk_main_session(path: Path, since: str, until: str,
+                      unknown_models: set[str]) -> list[dict]:
+    """Walk a main-session JSONL, attributing each assistant turn to a skill
+    via the windowing rule (Skill invocation → next user message)."""
+    records: list[dict] = []
+    active_skill: str | None = None
+    try:
+        with path.open("r", encoding="utf-8") as fp:
+            for line in fp:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                etype = entry.get("type")
+                if etype == "user" and is_real_user_turn(entry):
+                    active_skill = None
+                    continue
+                if etype != "assistant":
+                    continue
+                # Update the active skill BEFORE emitting the record so the
+                # turn that invoked the skill is attributed to that skill.
+                for tu in extract_tool_uses(entry):
+                    if tu.get("name") == "Skill":
+                        skill = (tu.get("input") or {}).get("skill")
+                        if skill:
+                            active_skill = skill
+                if not in_window(entry.get("timestamp", ""), since, until):
+                    continue
+                msg = entry.get("message") or {}
+                usage = msg.get("usage") or {}
+                model_canon = canonicalize_model(msg.get("model") or "")
+                cost = turn_cost_usd(model_canon, usage, unknown_models)
+                records.append({
+                    "timestamp": entry.get("timestamp"),
+                    "model": model_canon,
+                    "is_sidechain": False,
+                    "skill": active_skill,
+                    "agent_type": None,
+                    "session_id": entry.get("sessionId"),
+                    "git_branch": entry.get("gitBranch"),
+                    "message_id": msg.get("id"),
+                    "request_id": entry.get("requestId"),
+                    "context_tokens": context_size(usage),
+                    "output_tokens": usage.get("output_tokens") or 0,
+                    "cost_usd": cost,
+                })
+    except OSError:
+        pass
+    return records
+
+
+def walk_subagent_file(path: Path, since: str, until: str,
+                       unknown_models: set[str]) -> list[dict]:
+    """Walk an agent-*.jsonl, using the harness-provided attribution fields."""
+    records: list[dict] = []
+    try:
+        with path.open("r", encoding="utf-8") as fp:
+            for line in fp:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("type") != "assistant":
+                    continue
+                if not in_window(entry.get("timestamp", ""), since, until):
+                    continue
+                msg = entry.get("message") or {}
+                usage = msg.get("usage") or {}
+                model_canon = canonicalize_model(msg.get("model") or "")
+                cost = turn_cost_usd(model_canon, usage, unknown_models)
+                records.append({
+                    "timestamp": entry.get("timestamp"),
+                    "model": model_canon,
+                    "is_sidechain": True,
+                    "skill": entry.get("attributionSkill"),
+                    "agent_type": entry.get("attributionAgent"),
+                    "session_id": entry.get("sessionId"),
+                    "git_branch": entry.get("gitBranch"),
+                    "message_id": msg.get("id"),
+                    "request_id": entry.get("requestId"),
+                    "context_tokens": context_size(usage),
+                    "output_tokens": usage.get("output_tokens") or 0,
+                    "cost_usd": cost,
+                })
+    except OSError:
+        pass
+    return records
+
+
+def collect_all(projects_dir: Path, since: str, until: str,
+                unknown_models: set[str]) -> list[dict]:
+    """Walk every JSONL under projects_dir, classifying main vs subagent by name.
+
+    Deduplicates by (message_id, request_id). The same message often appears in
+    multiple project dirs (e.g., when a session spans worktrees), and ccusage
+    applies the same dedup rule — without it our totals come in ~2x too high.
+    """
+    raw: list[dict] = []
+    for jsonl in projects_dir.rglob("*.jsonl"):
+        if jsonl.name.startswith("agent-"):
+            raw.extend(walk_subagent_file(jsonl, since, until, unknown_models))
+        else:
+            raw.extend(walk_main_session(jsonl, since, until, unknown_models))
+    seen: set = set()
+    deduped: list[dict] = []
+    for r in raw:
+        key = (r.get("message_id"), r.get("request_id"))
+        # Records without IDs (defensive: shouldn't happen for assistant turns)
+        # pass through unchecked rather than collapsing to a single entry.
+        if key != (None, None) and key in seen:
+            continue
+        seen.add(key)
+        deduped.append(r)
+    return deduped
+
+
+def aggregate_per_skill(records: list[dict]) -> list[dict]:
+    """Group by skill name. Unattributed turns bucket as '(no skill)'."""
+    by_skill: dict[str, list[dict]] = defaultdict(list)
+    for r in records:
+        key = r["skill"] or "(no skill)"
+        by_skill[key].append(r)
+    rows = []
+    for skill, turns in by_skill.items():
+        costs = [t["cost_usd"] for t in turns]
+        ctx = [t["context_tokens"] for t in turns]
+        model_costs: dict[str, float] = defaultdict(float)
+        for t in turns:
+            model_costs[t["model"]] += t["cost_usd"]
+        total_cost = sum(costs)
+        model_share = {
+            m: round((c / total_cost) * 100, 1) if total_cost else 0.0
+            for m, c in sorted(model_costs.items(), key=lambda kv: -kv[1])
+        }
+        rows.append({
+            "skill": skill,
+            "total_cost_usd": round(total_cost, 2),
+            "turn_count": len(turns),
+            "sidechain_turn_count": sum(1 for t in turns if t["is_sidechain"]),
+            "mean_context_tokens": round(sum(ctx) / len(ctx)) if ctx else 0,
+            "p95_context_tokens": round(percentile(ctx, 95)),
+            "max_context_tokens": max(ctx) if ctx else 0,
+            "model_share_pct": model_share,
+        })
+    rows.sort(key=lambda r: -r["total_cost_usd"])
+    return rows
+
+
+def aggregate_per_agent_type(records: list[dict]) -> list[dict]:
+    """Sidechain-only breakdown by attributionAgent."""
+    by_agent: dict[str, list[dict]] = defaultdict(list)
+    for r in records:
+        if not r["is_sidechain"]:
+            continue
+        by_agent[r["agent_type"] or "(unknown)"].append(r)
+    rows = []
+    for agent, turns in by_agent.items():
+        costs = [t["cost_usd"] for t in turns]
+        rows.append({
+            "agent_type": agent,
+            "total_cost_usd": round(sum(costs), 2),
+            "turn_count": len(turns),
+            "mean_cost_per_turn_usd": round(sum(costs) / len(costs), 4) if costs else 0.0,
+        })
+    rows.sort(key=lambda r: -r["total_cost_usd"])
+    return rows
+
+
+def main_vs_sidechain(records: list[dict]) -> dict:
+    main_cost = sum(r["cost_usd"] for r in records if not r["is_sidechain"])
+    side_cost = sum(r["cost_usd"] for r in records if r["is_sidechain"])
+    total = main_cost + side_cost
+    return {
+        "main_thread_cost_usd": round(main_cost, 2),
+        "sidechain_cost_usd": round(side_cost, 2),
+        "main_thread_pct": round((main_cost / total) * 100, 1) if total else 0.0,
+        "sidechain_pct": round((side_cost / total) * 100, 1) if total else 0.0,
+    }
+
+
+def top_turns(records: list[dict], n: int) -> list[dict]:
+    sorted_recs = sorted(records, key=lambda r: -r["cost_usd"])[:n]
+    return [
+        {
+            "timestamp": r["timestamp"],
+            "cost_usd": round(r["cost_usd"], 2),
+            "model": r["model"],
+            "context_tokens": r["context_tokens"],
+            "output_tokens": r["output_tokens"],
+            "session_suffix": (r["session_id"] or "")[-8:],
+            "git_branch": r["git_branch"],
+            "skill": r["skill"] or "(no skill)",
+            "is_sidechain": r["is_sidechain"],
+            "agent_type": r["agent_type"],
+        }
+        for r in sorted_recs
+    ]
+
+
+def resolve_ccusage(override: str | None) -> list[str] | None:
+    """Returns a runnable command, or None if neither ccusage nor npx is on PATH."""
+    if override is not None:
+        parts = override.split()
+        if not parts:
+            return None
+        resolved = shutil.which(parts[0])
+        if resolved:
+            parts[0] = resolved
+        return parts
+    ccusage_path = shutil.which("ccusage")
+    if ccusage_path:
+        return [ccusage_path]
+    npx_path = shutil.which("npx")
+    if npx_path:
+        return [npx_path, "-y", "ccusage@latest"]
+    return None
+
+
+def reconcile_with_ccusage(cmd: list[str], since: str, until: str,
+                           our_total: float) -> dict:
+    """Cross-check our local total against ccusage. Non-fatal on mismatch."""
+    since_yyyymmdd = datetime.strptime(since, "%Y-%m-%d").strftime("%Y%m%d")
+    until_yyyymmdd = datetime.strptime(until, "%Y-%m-%d").strftime("%Y%m%d")
+    args = cmd + ["daily", "--json", "--since", since_yyyymmdd,
+                  "--until", until_yyyymmdd, "--mode", "calculate", "--timezone", "UTC"]
+    try:
+        result = subprocess.run(args, capture_output=True, text=True,
+                                check=False, timeout=900)
+        if result.returncode != 0:
+            return {"status": "error", "detail": result.stderr.strip()[:200]}
+        data = json.loads(result.stdout)
+    except (FileNotFoundError, subprocess.TimeoutExpired,
+            json.JSONDecodeError) as exc:
+        return {"status": "error", "detail": str(exc)}
+    ccusage_total = (data.get("totals") or {}).get("totalCost") or 0.0
+    if ccusage_total <= 0:
+        return {"status": "no_data", "ccusage_total_usd": ccusage_total}
+    drift_pct = abs(our_total - ccusage_total) / ccusage_total * 100
+    return {
+        "status": "ok",
+        "ccusage_total_usd": round(ccusage_total, 2),
+        "our_total_usd": round(our_total, 2),
+        "drift_pct": round(drift_pct, 2),
+        "exceeded_threshold": drift_pct > RECONCILE_WARN_PCT,
+    }
+
+
+def render_markdown(report: dict, top_n: int) -> str:
+    window = report["window"]
+    split = report["main_vs_sidechain"]
+    lines = [
+        f"# Claude Code Skill Attribution - {report['user']}",
+        "",
+        f"**Window:** {window['since']} to {window['until']} ({window['days']} days, UTC)",
+        f"**Generated:** {report['generated']}",
+        f"**Schema:** v{report['schema_version']}",
+        f"**Total spend (local calc):** ${report['total_cost_usd']:,.2f} "
+        f"across {report['turn_count']:,} assistant turns",
+        "",
+    ]
+
+    rec = report.get("reconcile") or {}
+    if rec.get("status") == "ok":
+        marker = " WARN drift > threshold" if rec.get("exceeded_threshold") else ""
+        lines += [
+            f"**Reconcile vs ccusage:** ours ${rec['our_total_usd']:,.2f} | "
+            f"ccusage ${rec['ccusage_total_usd']:,.2f} | "
+            f"drift {rec['drift_pct']}%{marker}",
+            "",
+            "_Ours is typically a few percent higher because ccusage doesn't "
+            "read `agent-*.jsonl` subagent transcripts; that spend is real but "
+            "invisible to ccusage. Drift above 20% suggests stale rates._",
+            "",
+        ]
+    elif rec.get("status") == "error":
+        lines += [f"**Reconcile vs ccusage:** skipped ({rec.get('detail','error')})", ""]
+    elif rec.get("status") == "no_data":
+        lines += ["**Reconcile vs ccusage:** ccusage reported no data for window", ""]
+
+    if report.get("unknown_models"):
+        lines += [
+            f"**WARNING:** unknown models (no rates in PRICES dict): "
+            f"{', '.join(sorted(report['unknown_models']))} - their cost is reported as $0.",
+            "",
+        ]
+
+    lines += [
+        "## Main thread vs subagent split",
+        "",
+        f"- Main thread: **${split['main_thread_cost_usd']:,.2f}** ({split['main_thread_pct']}%)",
+        f"- Subagent (sidechain): **${split['sidechain_cost_usd']:,.2f}** ({split['sidechain_pct']}%)",
+        "",
+        "## Per-skill spend",
+        "",
+        "| Skill | Cost | Turns | Sidechain turns | Mean ctx (tok) | p95 ctx | Top model share |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for row in report["per_skill"]:
+        share = row["model_share_pct"]
+        share_str = ", ".join(f"{m} {p}%" for m, p in list(share.items())[:2]) or "-"
+        lines.append(
+            f"| `{row['skill']}` | ${row['total_cost_usd']:,.2f} | {row['turn_count']:,} | "
+            f"{row['sidechain_turn_count']:,} | {row['mean_context_tokens']:,} | "
+            f"{row['p95_context_tokens']:,} | {share_str} |"
+        )
+
+    lines += ["", "## Per-subagent_type spend (sidechain only)", "",
+              "| Agent type | Cost | Turns | Mean $/turn |",
+              "| --- | ---: | ---: | ---: |"]
+    for row in report["per_agent_type"]:
+        lines.append(
+            f"| `{row['agent_type']}` | ${row['total_cost_usd']:,.2f} | "
+            f"{row['turn_count']:,} | ${row['mean_cost_per_turn_usd']:,.4f} |"
+        )
+    if not report["per_agent_type"]:
+        lines.append("| _(no sidechain turns in window)_ | | | |")
+
+    lines += ["", f"## Top {top_n} most expensive turns", "",
+              "| Time | Cost | Model | Ctx (tok) | Out (tok) | Session | Branch | Skill | Sidechain |",
+              "| --- | ---: | --- | ---: | ---: | --- | --- | --- | :---: |"]
+    for t in report["top_turns"]:
+        lines.append(
+            f"| {t['timestamp']} | ${t['cost_usd']:,.2f} | `{t['model']}` | "
+            f"{t['context_tokens']:,} | {t['output_tokens']:,} | "
+            f"`...{t['session_suffix']}` | `{t['git_branch'] or '-'}` | "
+            f"`{t['skill']}` | {'Y' if t['is_sidechain'] else 'N'} |"
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    if args.until < args.since:
+        sys.exit(f"error: --until ({args.until}) is before --since ({args.since}).")
+
+    user = sanitize_user(args.user) if args.user else derive_user()
+    out_dir = Path(args.out_dir).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    projects_dir = (Path(args.projects_dir).expanduser() if args.projects_dir
+                    else Path.home() / ".claude" / "projects")
+    if not projects_dir.is_dir():
+        sys.exit(f"error: projects directory not found: {projects_dir}")
+
+    print(f"Reading transcripts from {projects_dir}", file=sys.stderr)
+    print(f"Window: {args.since} to {args.until} (UTC)", file=sys.stderr)
+
+    unknown_models: set[str] = set()
+    records = collect_all(projects_dir, args.since, args.until, unknown_models)
+    print(f"Collected {len(records):,} assistant turns in window.", file=sys.stderr)
+
+    total_cost = sum(r["cost_usd"] for r in records)
+    window_days = (datetime.strptime(args.until, "%Y-%m-%d")
+                   - datetime.strptime(args.since, "%Y-%m-%d")).days + 1
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "user": user,
+        "generated": date.today().isoformat(),
+        "window": {"since": args.since, "until": args.until, "days": window_days},
+        "total_cost_usd": round(total_cost, 2),
+        "turn_count": len(records),
+        "unknown_models": sorted(unknown_models),
+        "main_vs_sidechain": main_vs_sidechain(records),
+        "per_skill": aggregate_per_skill(records),
+        "per_agent_type": aggregate_per_agent_type(records),
+        "top_turns": top_turns(records, args.top),
+    }
+
+    if not args.no_reconcile:
+        ccmd = resolve_ccusage(args.ccusage)
+        if ccmd is None:
+            report["reconcile"] = {"status": "error",
+                                   "detail": "ccusage/npx not on PATH"}
+        else:
+            print(f"Reconciling against ccusage: {' '.join(ccmd)}", file=sys.stderr)
+            report["reconcile"] = reconcile_with_ccusage(
+                ccmd, args.since, args.until, total_cost)
+
+    md_path = out_dir / f"{user}-attribution.md"
+    json_path = out_dir / f"{user}-attribution.json"
+    md_path.write_text(render_markdown(report, args.top), encoding="utf-8")
+    json_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Wrote {md_path}")
+    print(f"Wrote {json_path}")
+    print(f"Total: ${report['total_cost_usd']:,.2f} across {report['turn_count']:,} turns")
+    rec = report.get("reconcile") or {}
+    if rec.get("status") == "ok" and rec.get("exceeded_threshold"):
+        print(f"WARNING: drift vs ccusage is {rec['drift_pct']}% (>{RECONCILE_WARN_PCT}%). "
+              "PRICES dict may be stale.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/claude-skill-attribution.py
+++ b/scripts/claude-skill-attribution.py
@@ -241,6 +241,27 @@ def is_real_user_turn(entry: dict) -> bool:
     return True
 
 
+SLASH_COMMAND_RE = re.compile(r"<command-name>/(.+?)</command-name>")
+
+
+def extract_slash_command_skill(entry: dict) -> str | None:
+    """Detect skills invoked via a typed slash command.
+
+    The harness wraps slash commands as `<command-name>/skill-name</command-name>`
+    in the user message content; no Skill tool_use is emitted, so we have to
+    detect it from the user-side string. The skill name may be plugin-namespaced
+    (e.g. `deep-review:deep-review`).
+    """
+    if entry.get("type") != "user":
+        return None
+    msg = entry.get("message") or {}
+    content = msg.get("content")
+    if not isinstance(content, str):
+        return None
+    match = SLASH_COMMAND_RE.search(content)
+    return match.group(1) if match else None
+
+
 def extract_tool_uses(entry: dict) -> list[dict]:
     msg = entry.get("message") or {}
     content = msg.get("content")
@@ -252,7 +273,10 @@ def extract_tool_uses(entry: dict) -> list[dict]:
 def walk_main_session(path: Path, since: str, until: str,
                       unknown_models: set[str]) -> list[dict]:
     """Walk a main-session JSONL, attributing each assistant turn to a skill
-    via the windowing rule (Skill invocation → next user message)."""
+    via the windowing rule. Skills can be invoked two ways:
+      1. A `Skill` tool_use in an assistant turn (rare from main thread).
+      2. A typed slash-command in a user message — `<command-name>/X</command-name>`.
+    Both open the window through the next real user turn."""
     records: list[dict] = []
     active_skill: str | None = None
     try:
@@ -264,12 +288,13 @@ def walk_main_session(path: Path, since: str, until: str,
                     continue
                 etype = entry.get("type")
                 if etype == "user" and is_real_user_turn(entry):
-                    active_skill = None
+                    # Slash-command user turns OPEN a window; plain user turns
+                    # close the prior one. Order matters: detect slash first.
+                    slash = extract_slash_command_skill(entry)
+                    active_skill = slash  # None if not a slash command
                     continue
                 if etype != "assistant":
                     continue
-                # Update the active skill BEFORE emitting the record so the
-                # turn that invoked the skill is attributed to that skill.
                 for tu in extract_tool_uses(entry):
                     if tu.get("name") == "Skill":
                         skill = (tu.get("input") or {}).get("skill")
@@ -353,11 +378,18 @@ def walk_main_session_invocations(path: Path, since: str, until: str,
     the skill had to inherit) and the cost of the entire skill window. Lets us
     flag skills that are repeatedly invoked deep into bloated sessions.
 
+    Skills enter via two paths and both are handled:
+      1. `Skill` tool_use in an assistant turn → ctx_at_invoke is THIS turn.
+      2. `<command-name>/X</command-name>` in a user turn → the user message
+         itself has no usage block, so ctx_at_invoke is the FIRST assistant
+         turn that follows. We track this with a `pending_slash_skill` flag.
+
     Subagents start fresh, so they're not the question — only main-session
     JSONLs feed this walker.
     """
     records: list[dict] = []
     active: dict | None = None  # in-flight invocation accumulator
+    pending_slash_skill: str | None = None
 
     def close(active_state: dict | None) -> None:
         if active_state is None:
@@ -375,37 +407,41 @@ def walk_main_session_invocations(path: Path, since: str, until: str,
                 if etype == "user" and is_real_user_turn(entry):
                     close(active)
                     active = None
+                    pending_slash_skill = extract_slash_command_skill(entry)
                     continue
                 if etype != "assistant":
                     continue
                 msg = entry.get("message") or {}
                 usage = msg.get("usage") or {}
                 model_canon = canonicalize_model(msg.get("model") or "")
-                # When a Skill tool_use appears, close any prior window and open a new one.
-                # The invocation turn itself is included in the new window.
-                for tu in extract_tool_uses(entry):
-                    if tu.get("name") == "Skill":
-                        skill = (tu.get("input") or {}).get("skill")
-                        if skill:
-                            close(active)
-                            if not in_window(entry.get("timestamp", ""), since, until):
-                                active = None
-                                continue
-                            active = {
-                                "skill": skill,
-                                "timestamp": entry.get("timestamp"),
-                                "session_id": entry.get("sessionId"),
-                                "git_branch": entry.get("gitBranch"),
-                                "model_at_invoke": model_canon,
-                                "ctx_at_invoke": context_size(usage),
-                                "n_turns": 0,
-                                "window_cost_usd": 0.0,
-                                "wasted_cache_read_lb_usd": 0.0,
-                            }
+                ts = entry.get("timestamp", "")
+                # If both signals fire on the same turn, the explicit Skill
+                # tool_use wins. Otherwise the pending slash-command opens it.
+                tool_skill = next(
+                    ((tu.get("input") or {}).get("skill") for tu in extract_tool_uses(entry)
+                     if tu.get("name") == "Skill" and (tu.get("input") or {}).get("skill")),
+                    None,
+                )
+                opened_by = tool_skill or pending_slash_skill
+                pending_slash_skill = None
+                if opened_by is not None:
+                    close(active)
+                    active = None
+                    if in_window(ts, since, until):
+                        active = {
+                            "skill": opened_by,
+                            "timestamp": ts,
+                            "session_id": entry.get("sessionId"),
+                            "git_branch": entry.get("gitBranch"),
+                            "model_at_invoke": model_canon,
+                            "ctx_at_invoke": context_size(usage),
+                            "n_turns": 0,
+                            "window_cost_usd": 0.0,
+                            "wasted_cache_read_lb_usd": 0.0,
+                        }
                 if active is not None:
                     active["n_turns"] += 1
                     active["window_cost_usd"] += turn_cost_usd(model_canon, usage, unknown_models)
-                    # Floor: every turn re-reads at least the inherited context.
                     active["wasted_cache_read_lb_usd"] += (
                         active["ctx_at_invoke"] * cache_read_rate(model_canon))
             close(active)

--- a/scripts/test_claude_skill_attribution_unit.py
+++ b/scripts/test_claude_skill_attribution_unit.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/claude-skill-attribution.py.
+
+Functions tested in isolation: canonicalize_model, parse_iso_date, sanitize_user,
+percentile, turn_cost_usd, context_size, in_window, is_real_user_turn,
+extract_tool_uses, walk_main_session (via tmp file), aggregate_per_skill,
+aggregate_per_agent_type, main_vs_sidechain, top_turns.
+
+Run directly: python scripts/test_claude_skill_attribution_unit.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _load_module():
+    """Load claude-skill-attribution.py despite the hyphen in the filename."""
+    script_path = Path(__file__).parent / "claude-skill-attribution.py"
+    spec = importlib.util.spec_from_file_location("claude_skill_attribution", script_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["claude_skill_attribution"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+csa = _load_module()
+
+
+class CanonicalizeModelTests(unittest.TestCase):
+    def test_canonicalize_model_strips_trailing_yyyymmdd(self):
+        # Arrange
+        const_dated = "claude-haiku-4-5-20251001"
+        const_expected = "claude-haiku-4-5"
+        # Act
+        result = csa.canonicalize_model(const_dated)
+        # Assert
+        self.assertEqual(result, const_expected)
+
+    def test_canonicalize_model_undated_passes_through(self):
+        # Arrange
+        const_input = "claude-opus-4-7"
+        # Act
+        result = csa.canonicalize_model(const_input)
+        # Assert
+        self.assertEqual(result, const_input)
+
+    def test_canonicalize_model_empty_returns_empty(self):
+        # Arrange / Act
+        result = csa.canonicalize_model("")
+        # Assert
+        self.assertEqual(result, "")
+
+    def test_canonicalize_model_partial_date_not_stripped(self):
+        # Arrange — only a 6-digit suffix; canonical form should leave it alone
+        const_input = "claude-foo-202510"
+        # Act
+        result = csa.canonicalize_model(const_input)
+        # Assert
+        self.assertEqual(result, const_input)
+
+
+class ParseIsoDateTests(unittest.TestCase):
+    def test_parse_iso_date_valid_returns_unchanged(self):
+        # Arrange
+        const_iso = "2026-05-07"
+        # Act
+        result = csa.parse_iso_date(const_iso)
+        # Assert
+        self.assertEqual(result, const_iso)
+
+    def test_parse_iso_date_invalid_format_raises(self):
+        # Arrange
+        const_bad = "2026/05/07"
+        # Act / Assert
+        with self.assertRaises(argparse.ArgumentTypeError):
+            csa.parse_iso_date(const_bad)
+
+
+class SanitizeUserTests(unittest.TestCase):
+    def test_sanitize_user_normalizes_case_and_spaces(self):
+        # Arrange
+        const_input = "Tim Zander"
+        const_expected = "tim_zander"
+        # Act
+        result = csa.sanitize_user(const_input)
+        # Assert
+        self.assertEqual(result, const_expected)
+
+    def test_sanitize_user_only_unsafe_falls_back_to_default(self):
+        # Arrange
+        const_input = "../"
+        const_expected = "user"
+        # Act
+        result = csa.sanitize_user(const_input)
+        # Assert
+        self.assertEqual(result, const_expected)
+
+
+class PercentileTests(unittest.TestCase):
+    def test_percentile_empty_list_returns_zero(self):
+        # Arrange / Act
+        result = csa.percentile([], 50)
+        # Assert
+        self.assertEqual(result, 0.0)
+
+    def test_percentile_p95_of_uniform_returns_max_for_small_n(self):
+        # Arrange
+        values = [1, 2, 3, 4, 5]
+        const_expected = 4.8  # k=(5-1)*0.95=3.8 → interp(sorted[3]=4, sorted[4]=5)
+        # Act
+        result = csa.percentile(values, 95)
+        # Assert
+        self.assertAlmostEqual(result, const_expected)
+
+
+class TurnCostUsdTests(unittest.TestCase):
+    def test_turn_cost_unknown_model_recorded_and_zero(self):
+        # Arrange
+        const_unknown = "made-up-model"
+        unknown: set[str] = set()
+        usage = {"input_tokens": 1000, "output_tokens": 500}
+        # Act
+        cost = csa.turn_cost_usd(const_unknown, usage, unknown)
+        # Assert
+        self.assertEqual(cost, 0.0)
+        self.assertIn(const_unknown, unknown)
+
+    def test_turn_cost_opus_47_pure_input_output(self):
+        # Arrange — Opus 4.5+ tier: 1M input ($5) + 1M output ($25) = $30
+        const_million = 1_000_000
+        const_expected = 30.0
+        usage = {"input_tokens": const_million, "output_tokens": const_million}
+        unknown: set[str] = set()
+        # Act
+        cost = csa.turn_cost_usd("claude-opus-4-7", usage, unknown)
+        # Assert
+        self.assertAlmostEqual(cost, const_expected, places=4)
+        self.assertEqual(unknown, set())
+
+    def test_turn_cost_opus_4_1_uses_old_higher_tier(self):
+        # Arrange — Opus 4.1 stayed at $15/$75; verifies tiers don't bleed
+        const_million = 1_000_000
+        const_expected = 90.0
+        usage = {"input_tokens": const_million, "output_tokens": const_million}
+        unknown: set[str] = set()
+        # Act
+        cost = csa.turn_cost_usd("claude-opus-4-1", usage, unknown)
+        # Assert
+        self.assertAlmostEqual(cost, const_expected, places=4)
+
+    def test_turn_cost_uses_breakdown_when_present(self):
+        # Arrange — Opus 4.5+ tier: 1M of 1h cache creation at $10/MTok
+        const_million = 1_000_000
+        const_expected = 10.0
+        usage = {
+            "cache_creation_input_tokens": const_million,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 0,
+                "ephemeral_1h_input_tokens": const_million,
+            },
+        }
+        unknown: set[str] = set()
+        # Act
+        cost = csa.turn_cost_usd("claude-opus-4-7", usage, unknown)
+        # Assert
+        self.assertAlmostEqual(cost, const_expected, places=4)
+
+    def test_turn_cost_falls_back_to_5m_rate_when_breakdown_missing(self):
+        # Arrange — older transcripts: only the rolled-up cache_creation_input_tokens.
+        # Opus 4.5+ 5m rate: $6.25/MTok.
+        const_million = 1_000_000
+        const_expected = 6.25
+        usage = {"cache_creation_input_tokens": const_million}
+        unknown: set[str] = set()
+        # Act
+        cost = csa.turn_cost_usd("claude-opus-4-7", usage, unknown)
+        # Assert
+        self.assertAlmostEqual(cost, const_expected, places=4)
+
+    def test_turn_cost_cache_read_at_discounted_rate(self):
+        # Arrange — Opus 4.5+ cache_read at $0.50/MTok
+        const_million = 1_000_000
+        const_expected = 0.50
+        usage = {"cache_read_input_tokens": const_million}
+        unknown: set[str] = set()
+        # Act
+        cost = csa.turn_cost_usd("claude-opus-4-7", usage, unknown)
+        # Assert
+        self.assertAlmostEqual(cost, const_expected, places=4)
+
+    def test_turn_cost_haiku_cheaper_than_opus(self):
+        # Arrange — Opus 4.5+ input is $5/MTok, Haiku is $1/MTok → 5x ratio
+        const_million = 1_000_000
+        const_expected_ratio = 5.0
+        usage = {"input_tokens": const_million, "output_tokens": 0}
+        unknown: set[str] = set()
+        # Act
+        opus = csa.turn_cost_usd("claude-opus-4-7", usage, unknown)
+        haiku = csa.turn_cost_usd("claude-haiku-4-5", usage, unknown)
+        # Assert
+        self.assertAlmostEqual(opus / haiku, const_expected_ratio, places=4)
+
+
+class ContextSizeTests(unittest.TestCase):
+    def test_context_size_sums_input_and_cache_tokens(self):
+        # Arrange — input + cache_read + cache_creation, output excluded
+        const_input = 100
+        const_cache_read = 5000
+        const_cache_create = 200
+        const_output_excluded = 999_999
+        usage = {
+            "input_tokens": const_input,
+            "cache_read_input_tokens": const_cache_read,
+            "cache_creation_input_tokens": const_cache_create,
+            "output_tokens": const_output_excluded,
+        }
+        const_expected = const_input + const_cache_read + const_cache_create
+        # Act
+        result = csa.context_size(usage)
+        # Assert
+        self.assertEqual(result, const_expected)
+
+    def test_context_size_handles_missing_fields_as_zero(self):
+        # Arrange / Act
+        result = csa.context_size({})
+        # Assert
+        self.assertEqual(result, 0)
+
+
+class InWindowTests(unittest.TestCase):
+    def test_in_window_inclusive_on_both_ends(self):
+        # Arrange
+        const_since = "2026-04-01"
+        const_until = "2026-04-30"
+        # Act / Assert — both edges count
+        self.assertTrue(csa.in_window("2026-04-01T00:00:00Z", const_since, const_until))
+        self.assertTrue(csa.in_window("2026-04-30T23:59:59Z", const_since, const_until))
+
+    def test_in_window_outside_returns_false(self):
+        # Arrange
+        const_since = "2026-04-01"
+        const_until = "2026-04-30"
+        # Act / Assert
+        self.assertFalse(csa.in_window("2026-03-31T23:59:59Z", const_since, const_until))
+        self.assertFalse(csa.in_window("2026-05-01T00:00:00Z", const_since, const_until))
+
+    def test_in_window_empty_timestamp_returns_false(self):
+        # Arrange / Act
+        result = csa.in_window("", "2026-04-01", "2026-04-30")
+        # Assert
+        self.assertFalse(result)
+
+
+class IsRealUserTurnTests(unittest.TestCase):
+    def test_is_real_user_turn_string_content_is_real(self):
+        # Arrange — typed user prompt
+        entry = {"type": "user", "message": {"content": "hello"}}
+        # Act / Assert
+        self.assertTrue(csa.is_real_user_turn(entry))
+
+    def test_is_real_user_turn_tool_result_only_is_not_real(self):
+        # Arrange — tool turn shouldn't end the skill window
+        entry = {"type": "user", "message": {"content": [
+            {"type": "tool_result", "content": "ok"}
+        ]}}
+        # Act / Assert
+        self.assertFalse(csa.is_real_user_turn(entry))
+
+    def test_is_real_user_turn_meta_is_not_real(self):
+        # Arrange — local-command-caveat and other meta messages
+        entry = {"type": "user", "isMeta": True, "message": {"content": "x"}}
+        # Act / Assert
+        self.assertFalse(csa.is_real_user_turn(entry))
+
+    def test_is_real_user_turn_assistant_type_is_not_real(self):
+        # Arrange
+        entry = {"type": "assistant", "message": {"content": "x"}}
+        # Act / Assert
+        self.assertFalse(csa.is_real_user_turn(entry))
+
+
+class ExtractToolUsesTests(unittest.TestCase):
+    def test_extract_tool_uses_filters_to_tool_use_blocks_only(self):
+        # Arrange
+        entry = {"message": {"content": [
+            {"type": "text", "text": "hello"},
+            {"type": "tool_use", "name": "Read", "input": {"file_path": "/x"}},
+            {"type": "thinking", "thinking": "plan"},
+            {"type": "tool_use", "name": "Skill", "input": {"skill": "foo"}},
+        ]}}
+        # Act
+        result = csa.extract_tool_uses(entry)
+        # Assert
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["name"], "Read")
+        self.assertEqual(result[1]["name"], "Skill")
+
+    def test_extract_tool_uses_string_content_returns_empty(self):
+        # Arrange
+        entry = {"message": {"content": "plain text"}}
+        # Act
+        result = csa.extract_tool_uses(entry)
+        # Assert
+        self.assertEqual(result, [])
+
+
+class WalkMainSessionTests(unittest.TestCase):
+    def _write_jsonl(self, lines: list[dict]) -> Path:
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False, encoding="utf-8")
+        for entry in lines:
+            tmp.write(json.dumps(entry) + "\n")
+        tmp.close()
+        return Path(tmp.name)
+
+    def test_walk_main_session_skill_window_attributes_subsequent_turns(self):
+        # Arrange — user→assistant(skill foo)→assistant(in window)→user(reset)→assistant(none)
+        const_session = "abc12345"
+        const_branch = "branches/test"
+        const_timestamp = "2026-04-15T12:00:00Z"
+        lines = [
+            {"type": "user", "message": {"content": "hi"}, "timestamp": const_timestamp},
+            {"type": "assistant", "timestamp": const_timestamp,
+             "sessionId": const_session, "gitBranch": const_branch,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [{"type": "tool_use", "name": "Skill",
+                                      "input": {"skill": "foo"}}],
+                         "usage": {"input_tokens": 10, "output_tokens": 20}}},
+            {"type": "assistant", "timestamp": const_timestamp,
+             "sessionId": const_session, "gitBranch": const_branch,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [{"type": "text", "text": "still in foo"}],
+                         "usage": {"input_tokens": 5, "output_tokens": 7}}},
+            {"type": "user", "message": {"content": "next q"}, "timestamp": const_timestamp},
+            {"type": "assistant", "timestamp": const_timestamp,
+             "sessionId": const_session, "gitBranch": const_branch,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [{"type": "text", "text": "no skill"}],
+                         "usage": {"input_tokens": 2, "output_tokens": 3}}},
+        ]
+        path = self._write_jsonl(lines)
+        unknown: set[str] = set()
+        const_since = "2026-04-01"
+        const_until = "2026-04-30"
+        # Act
+        records = csa.walk_main_session(path, const_since, const_until, unknown)
+        # Assert — first 2 assistant turns attributed to "foo", third to None
+        path.unlink()
+        self.assertEqual(len(records), 3)
+        self.assertEqual(records[0]["skill"], "foo")
+        self.assertEqual(records[1]["skill"], "foo")
+        self.assertIsNone(records[2]["skill"])
+        self.assertFalse(any(r["is_sidechain"] for r in records))
+
+    def test_walk_main_session_tool_result_user_turn_does_not_reset_skill(self):
+        # Arrange — tool_result-only user message must not end the skill window
+        const_timestamp = "2026-04-15T12:00:00Z"
+        lines = [
+            {"type": "assistant", "timestamp": const_timestamp,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [{"type": "tool_use", "name": "Skill",
+                                      "input": {"skill": "foo"}}],
+                         "usage": {"input_tokens": 1, "output_tokens": 1}}},
+            {"type": "user", "message": {"content": [
+                {"type": "tool_result", "content": "ok"}]},
+             "timestamp": const_timestamp},
+            {"type": "assistant", "timestamp": const_timestamp,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [{"type": "text", "text": "still foo"}],
+                         "usage": {"input_tokens": 1, "output_tokens": 1}}},
+        ]
+        path = self._write_jsonl(lines)
+        unknown: set[str] = set()
+        # Act
+        records = csa.walk_main_session(path, "2026-04-01", "2026-04-30", unknown)
+        path.unlink()
+        # Assert — both assistant turns still inside the foo window
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0]["skill"], "foo")
+        self.assertEqual(records[1]["skill"], "foo")
+
+    def test_walk_main_session_filters_by_window(self):
+        # Arrange — one in-window, one out-of-window
+        const_in = "2026-04-15T12:00:00Z"
+        const_out = "2026-03-15T12:00:00Z"
+        lines = [
+            {"type": "assistant", "timestamp": const_in,
+             "message": {"model": "claude-opus-4-7", "content": [],
+                         "usage": {"input_tokens": 1, "output_tokens": 1}}},
+            {"type": "assistant", "timestamp": const_out,
+             "message": {"model": "claude-opus-4-7", "content": [],
+                         "usage": {"input_tokens": 1, "output_tokens": 1}}},
+        ]
+        path = self._write_jsonl(lines)
+        unknown: set[str] = set()
+        # Act
+        records = csa.walk_main_session(path, "2026-04-01", "2026-04-30", unknown)
+        path.unlink()
+        # Assert
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["timestamp"], const_in)
+
+
+class CollectAllDedupTests(unittest.TestCase):
+    def _write_jsonl(self, path: Path, lines: list[dict]) -> None:
+        with path.open("w", encoding="utf-8") as fp:
+            for entry in lines:
+                fp.write(json.dumps(entry) + "\n")
+
+    def test_collect_all_deduplicates_same_message_across_files(self):
+        # Arrange — same (message_id, request_id) appears in two project dirs
+        const_msg_id = "msg_abc"
+        const_req_id = "req_xyz"
+        const_timestamp = "2026-04-15T12:00:00Z"
+        shared_entry = {
+            "type": "assistant", "timestamp": const_timestamp,
+            "sessionId": "sess1", "gitBranch": "b", "requestId": const_req_id,
+            "message": {"id": const_msg_id, "model": "claude-opus-4-7",
+                        "content": [], "usage": {"input_tokens": 100, "output_tokens": 50}},
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "proj-a").mkdir()
+            (root / "proj-b").mkdir()
+            self._write_jsonl(root / "proj-a" / "session-1.jsonl", [shared_entry])
+            self._write_jsonl(root / "proj-b" / "session-1.jsonl", [shared_entry])
+            unknown: set[str] = set()
+            # Act
+            records = csa.collect_all(root, "2026-04-01", "2026-04-30", unknown)
+        # Assert — appears twice raw, once after dedup
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["message_id"], const_msg_id)
+
+
+class AggregatePerSkillTests(unittest.TestCase):
+    def test_aggregate_per_skill_groups_and_sorts_by_cost_desc(self):
+        # Arrange
+        records = [
+            {"skill": "foo", "is_sidechain": False, "model": "claude-opus-4-7",
+             "context_tokens": 1000, "cost_usd": 5.0, "output_tokens": 100,
+             "timestamp": "t", "session_id": "s", "git_branch": "b",
+             "agent_type": None},
+            {"skill": "foo", "is_sidechain": True, "model": "claude-haiku-4-5",
+             "context_tokens": 2000, "cost_usd": 1.0, "output_tokens": 50,
+             "timestamp": "t", "session_id": "s", "git_branch": "b",
+             "agent_type": "Explore"},
+            {"skill": "bar", "is_sidechain": False, "model": "claude-opus-4-7",
+             "context_tokens": 500, "cost_usd": 10.0, "output_tokens": 80,
+             "timestamp": "t", "session_id": "s", "git_branch": "b",
+             "agent_type": None},
+        ]
+        # Act
+        rows = csa.aggregate_per_skill(records)
+        # Assert — bar ($10) ranks above foo ($6); foo has 2 turns including 1 sidechain
+        self.assertEqual(rows[0]["skill"], "bar")
+        self.assertEqual(rows[0]["total_cost_usd"], 10.0)
+        self.assertEqual(rows[1]["skill"], "foo")
+        self.assertEqual(rows[1]["total_cost_usd"], 6.0)
+        self.assertEqual(rows[1]["turn_count"], 2)
+        self.assertEqual(rows[1]["sidechain_turn_count"], 1)
+
+    def test_aggregate_per_skill_unattributed_buckets_to_no_skill(self):
+        # Arrange
+        records = [{"skill": None, "is_sidechain": False,
+                    "model": "claude-opus-4-7", "context_tokens": 100,
+                    "cost_usd": 2.0, "output_tokens": 5, "timestamp": "t",
+                    "session_id": "s", "git_branch": "b", "agent_type": None}]
+        # Act
+        rows = csa.aggregate_per_skill(records)
+        # Assert
+        self.assertEqual(rows[0]["skill"], "(no skill)")
+
+
+class AggregatePerAgentTypeTests(unittest.TestCase):
+    def test_aggregate_per_agent_type_excludes_main_thread(self):
+        # Arrange
+        records = [
+            {"is_sidechain": True, "agent_type": "Explore", "cost_usd": 3.0},
+            {"is_sidechain": False, "agent_type": None, "cost_usd": 100.0},
+            {"is_sidechain": True, "agent_type": "general-purpose", "cost_usd": 7.0},
+            {"is_sidechain": True, "agent_type": "Explore", "cost_usd": 2.0},
+        ]
+        # Act
+        rows = csa.aggregate_per_agent_type(records)
+        # Assert — main-thread $100 not in totals; Explore $5 from 2 turns sorts above general-purpose $7? No, gen-purpose=7 > explore=5
+        self.assertEqual(rows[0]["agent_type"], "general-purpose")
+        self.assertEqual(rows[0]["total_cost_usd"], 7.0)
+        self.assertEqual(rows[1]["agent_type"], "Explore")
+        self.assertEqual(rows[1]["total_cost_usd"], 5.0)
+        self.assertEqual(rows[1]["turn_count"], 2)
+
+
+class MainVsSidechainTests(unittest.TestCase):
+    def test_main_vs_sidechain_pct_split(self):
+        # Arrange — 75/25 split
+        records = [
+            {"is_sidechain": False, "cost_usd": 75.0},
+            {"is_sidechain": True, "cost_usd": 25.0},
+        ]
+        const_main_pct = 75.0
+        const_side_pct = 25.0
+        # Act
+        result = csa.main_vs_sidechain(records)
+        # Assert
+        self.assertEqual(result["main_thread_pct"], const_main_pct)
+        self.assertEqual(result["sidechain_pct"], const_side_pct)
+
+    def test_main_vs_sidechain_empty_returns_zero_pct(self):
+        # Arrange / Act
+        result = csa.main_vs_sidechain([])
+        # Assert
+        self.assertEqual(result["main_thread_pct"], 0.0)
+        self.assertEqual(result["sidechain_pct"], 0.0)
+
+
+class TopTurnsTests(unittest.TestCase):
+    def test_top_turns_returns_n_most_expensive_in_order(self):
+        # Arrange
+        records = [
+            {"timestamp": "t1", "cost_usd": 1.0, "model": "m", "context_tokens": 0,
+             "output_tokens": 0, "session_id": "abcdefgh12345678",
+             "git_branch": "b", "skill": "s", "is_sidechain": False, "agent_type": None},
+            {"timestamp": "t2", "cost_usd": 5.0, "model": "m", "context_tokens": 0,
+             "output_tokens": 0, "session_id": "abcdefgh12345678",
+             "git_branch": "b", "skill": "s", "is_sidechain": False, "agent_type": None},
+            {"timestamp": "t3", "cost_usd": 3.0, "model": "m", "context_tokens": 0,
+             "output_tokens": 0, "session_id": "abcdefgh12345678",
+             "git_branch": "b", "skill": "s", "is_sidechain": False, "agent_type": None},
+        ]
+        const_n = 2
+        # Act
+        result = csa.top_turns(records, const_n)
+        # Assert
+        self.assertEqual(len(result), const_n)
+        self.assertEqual(result[0]["timestamp"], "t2")
+        self.assertEqual(result[1]["timestamp"], "t3")
+        self.assertEqual(result[0]["session_suffix"], "12345678")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_claude_skill_attribution_unit.py
+++ b/scripts/test_claude_skill_attribution_unit.py
@@ -408,6 +408,129 @@ class WalkMainSessionTests(unittest.TestCase):
         self.assertEqual(records[0]["timestamp"], const_in)
 
 
+class WalkMainSessionInvocationsTests(unittest.TestCase):
+    def _write_jsonl(self, lines: list[dict]) -> Path:
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False, encoding="utf-8")
+        for entry in lines:
+            tmp.write(json.dumps(entry) + "\n")
+        tmp.close()
+        return Path(tmp.name)
+
+    def test_walk_invocations_captures_ctx_at_invoke(self):
+        # Arrange — single invocation at 100K-token context, then 2 more turns
+        const_ctx_input = 90_000
+        const_ctx_cache_read = 10_000
+        const_expected_ctx = const_ctx_input + const_ctx_cache_read
+        const_timestamp = "2026-04-15T12:00:00Z"
+        lines = [
+            {"type": "assistant", "timestamp": const_timestamp,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [{"type": "tool_use", "name": "Skill",
+                                      "input": {"skill": "deep-review"}}],
+                         "usage": {"input_tokens": const_ctx_input,
+                                   "cache_read_input_tokens": const_ctx_cache_read,
+                                   "output_tokens": 50}}},
+            {"type": "assistant", "timestamp": const_timestamp,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [], "usage": {"input_tokens": 5,
+                                                  "output_tokens": 7}}},
+        ]
+        path = self._write_jsonl(lines)
+        unknown: set[str] = set()
+        # Act
+        invs = csa.walk_main_session_invocations(
+            path, "2026-04-01", "2026-04-30", unknown)
+        path.unlink()
+        # Assert
+        self.assertEqual(len(invs), 1)
+        self.assertEqual(invs[0]["skill"], "deep-review")
+        self.assertEqual(invs[0]["ctx_at_invoke"], const_expected_ctx)
+        self.assertEqual(invs[0]["n_turns"], 2)
+        # Wasted = ctx * cache_read_rate * n_turns = 100K * 0.5/1M * 2 = $0.10
+        self.assertAlmostEqual(invs[0]["wasted_cache_read_lb_usd"], 0.10, places=4)
+
+    def test_walk_invocations_user_turn_closes_window(self):
+        # Arrange — skill, two turns, user interrupts, then a turn that should NOT count
+        const_timestamp = "2026-04-15T12:00:00Z"
+        lines = [
+            {"type": "assistant", "timestamp": const_timestamp,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [{"type": "tool_use", "name": "Skill",
+                                      "input": {"skill": "foo"}}],
+                         "usage": {"input_tokens": 100, "output_tokens": 1}}},
+            {"type": "user", "message": {"content": "stop"}, "timestamp": const_timestamp},
+            {"type": "assistant", "timestamp": const_timestamp,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [], "usage": {"input_tokens": 1, "output_tokens": 1}}},
+        ]
+        path = self._write_jsonl(lines)
+        unknown: set[str] = set()
+        # Act
+        invs = csa.walk_main_session_invocations(
+            path, "2026-04-01", "2026-04-30", unknown)
+        path.unlink()
+        # Assert — window was just the invocation turn itself
+        self.assertEqual(len(invs), 1)
+        self.assertEqual(invs[0]["n_turns"], 1)
+
+    def test_walk_invocations_two_skills_in_one_session(self):
+        # Arrange — two distinct skill invocations separated by a user turn
+        const_timestamp = "2026-04-15T12:00:00Z"
+        lines = [
+            {"type": "assistant", "timestamp": const_timestamp,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [{"type": "tool_use", "name": "Skill",
+                                      "input": {"skill": "alpha"}}],
+                         "usage": {"input_tokens": 1, "output_tokens": 1}}},
+            {"type": "user", "message": {"content": "next"}, "timestamp": const_timestamp},
+            {"type": "assistant", "timestamp": const_timestamp,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [{"type": "tool_use", "name": "Skill",
+                                      "input": {"skill": "beta"}}],
+                         "usage": {"input_tokens": 2, "output_tokens": 2}}},
+        ]
+        path = self._write_jsonl(lines)
+        unknown: set[str] = set()
+        # Act
+        invs = csa.walk_main_session_invocations(
+            path, "2026-04-01", "2026-04-30", unknown)
+        path.unlink()
+        # Assert
+        self.assertEqual(len(invs), 2)
+        self.assertEqual([i["skill"] for i in invs], ["alpha", "beta"])
+
+
+class AggregateSkillEfficiencyTests(unittest.TestCase):
+    def test_aggregate_skill_efficiency_sorts_by_wasted_desc(self):
+        # Arrange
+        invocations = [
+            {"skill": "cheap", "ctx_at_invoke": 1000, "n_turns": 5,
+             "window_cost_usd": 1.0, "wasted_cache_read_lb_usd": 0.01},
+            {"skill": "bloated", "ctx_at_invoke": 400_000, "n_turns": 16,
+             "window_cost_usd": 3.0, "wasted_cache_read_lb_usd": 3.2},
+            {"skill": "bloated", "ctx_at_invoke": 350_000, "n_turns": 14,
+             "window_cost_usd": 2.5, "wasted_cache_read_lb_usd": 2.45},
+        ]
+        # Act
+        rows = csa.aggregate_skill_efficiency(invocations)
+        # Assert — bloated first (most total wasted)
+        self.assertEqual(rows[0]["skill"], "bloated")
+        self.assertEqual(rows[0]["invocations"], 2)
+        self.assertEqual(rows[0]["mean_turns_per_invocation"], 15.0)
+        self.assertEqual(rows[1]["skill"], "cheap")
+
+    def test_aggregate_skill_efficiency_pct_wasted_capped_correctly(self):
+        # Arrange — 80% wasted
+        invocations = [{"skill": "x", "ctx_at_invoke": 100_000, "n_turns": 10,
+                        "window_cost_usd": 5.0, "wasted_cache_read_lb_usd": 4.0}]
+        const_expected_pct = 80.0
+        # Act
+        rows = csa.aggregate_skill_efficiency(invocations)
+        # Assert
+        self.assertEqual(rows[0]["wasted_pct"], const_expected_pct)
+
+
 class CollectAllDedupTests(unittest.TestCase):
     def _write_jsonl(self, path: Path, lines: list[dict]) -> None:
         with path.open("w", encoding="utf-8") as fp:

--- a/scripts/test_claude_skill_attribution_unit.py
+++ b/scripts/test_claude_skill_attribution_unit.py
@@ -408,6 +408,63 @@ class WalkMainSessionTests(unittest.TestCase):
         self.assertEqual(records[0]["timestamp"], const_in)
 
 
+class ExtractSlashCommandSkillTests(unittest.TestCase):
+    def test_extract_slash_skill_with_command_name_tags(self):
+        # Arrange
+        const_skill = "deep-review:deep-review"
+        entry = {"type": "user", "message": {
+            "content": f"<command-message>x</command-message>\n<command-name>/{const_skill}</command-name>"
+        }}
+        # Act
+        result = csa.extract_slash_command_skill(entry)
+        # Assert
+        self.assertEqual(result, const_skill)
+
+    def test_extract_slash_skill_bare_form(self):
+        # Arrange
+        const_skill = "start-work"
+        entry = {"type": "user", "message": {
+            "content": f"<command-name>/{const_skill}</command-name>"
+        }}
+        # Act
+        result = csa.extract_slash_command_skill(entry)
+        # Assert
+        self.assertEqual(result, const_skill)
+
+    def test_extract_slash_skill_with_args(self):
+        # Arrange — args appear as separate tags but skill name still extractable
+        const_skill = "deep-review:deep-review"
+        entry = {"type": "user", "message": {
+            "content": f"<command-name>/{const_skill}</command-name>\n<command-args>pr 820</command-args>"
+        }}
+        # Act
+        result = csa.extract_slash_command_skill(entry)
+        # Assert
+        self.assertEqual(result, const_skill)
+
+    def test_extract_slash_skill_returns_none_for_plain_text(self):
+        # Arrange
+        entry = {"type": "user", "message": {"content": "please review my PR"}}
+        # Act / Assert
+        self.assertIsNone(csa.extract_slash_command_skill(entry))
+
+    def test_extract_slash_skill_returns_none_for_assistant_turn(self):
+        # Arrange — only user messages should be parsed
+        entry = {"type": "assistant", "message": {
+            "content": "<command-name>/foo</command-name>"
+        }}
+        # Act / Assert
+        self.assertIsNone(csa.extract_slash_command_skill(entry))
+
+    def test_extract_slash_skill_returns_none_for_list_content(self):
+        # Arrange — slash commands always come through as string content
+        entry = {"type": "user", "message": {
+            "content": [{"type": "text", "text": "<command-name>/foo</command-name>"}]
+        }}
+        # Act / Assert
+        self.assertIsNone(csa.extract_slash_command_skill(entry))
+
+
 class WalkMainSessionInvocationsTests(unittest.TestCase):
     def _write_jsonl(self, lines: list[dict]) -> Path:
         tmp = tempfile.NamedTemporaryFile(
@@ -472,6 +529,66 @@ class WalkMainSessionInvocationsTests(unittest.TestCase):
         path.unlink()
         # Assert — window was just the invocation turn itself
         self.assertEqual(len(invs), 1)
+        self.assertEqual(invs[0]["n_turns"], 1)
+
+    def test_walk_invocations_slash_command_opens_window_on_next_assistant_turn(self):
+        # Arrange — user types /deep-review, next assistant turn is the invocation.
+        # ctx_at_invoke comes from THAT assistant turn, not from the user message.
+        const_input = 200_000
+        const_cache_read = 100_000
+        const_expected_ctx = const_input + const_cache_read
+        const_timestamp = "2026-04-15T12:00:00Z"
+        lines = [
+            {"type": "user", "timestamp": const_timestamp,
+             "message": {"content": "<command-name>/deep-review</command-name>"}},
+            {"type": "assistant", "timestamp": const_timestamp,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [{"type": "text", "text": "starting"}],
+                         "usage": {"input_tokens": const_input,
+                                   "cache_read_input_tokens": const_cache_read,
+                                   "output_tokens": 100}}},
+            {"type": "assistant", "timestamp": const_timestamp,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [], "usage": {"input_tokens": 5,
+                                                  "output_tokens": 10}}},
+        ]
+        path = self._write_jsonl(lines)
+        unknown: set[str] = set()
+        # Act
+        invs = csa.walk_main_session_invocations(
+            path, "2026-04-01", "2026-04-30", unknown)
+        path.unlink()
+        # Assert
+        self.assertEqual(len(invs), 1)
+        self.assertEqual(invs[0]["skill"], "deep-review")
+        self.assertEqual(invs[0]["ctx_at_invoke"], const_expected_ctx)
+        self.assertEqual(invs[0]["n_turns"], 2)
+
+    def test_walk_invocations_slash_then_skill_tool_use_does_not_double_count(self):
+        # Arrange — user types /foo and the assistant ALSO emits Skill tool_use
+        # for the same skill (defensive: harness might emit both). Should be
+        # one invocation, not two.
+        const_timestamp = "2026-04-15T12:00:00Z"
+        lines = [
+            {"type": "user", "timestamp": const_timestamp,
+             "message": {"content": "<command-name>/foo</command-name>"}},
+            {"type": "assistant", "timestamp": const_timestamp,
+             "message": {"model": "claude-opus-4-7",
+                         "content": [{"type": "tool_use", "name": "Skill",
+                                      "input": {"skill": "foo"}}],
+                         "usage": {"input_tokens": 100, "output_tokens": 1}}},
+        ]
+        path = self._write_jsonl(lines)
+        unknown: set[str] = set()
+        # Act
+        invs = csa.walk_main_session_invocations(
+            path, "2026-04-01", "2026-04-30", unknown)
+        path.unlink()
+        # Assert — Skill tool_use closes pending and opens new with same skill.
+        # We get exactly one invocation; the slash-command-opened active was
+        # replaced before any turns accumulated to it.
+        self.assertEqual(len(invs), 1)
+        self.assertEqual(invs[0]["skill"], "foo")
         self.assertEqual(invs[0]["n_turns"], 1)
 
     def test_walk_invocations_two_skills_in_one_session(self):


### PR DESCRIPTION
## Summary

- New `scripts/claude-skill-attribution.py` reads `~/.claude/projects/**/*.jsonl` directly so we can break spend down by skill, main-thread vs subagent, and `subagent_type` — questions ccusage can't answer because it doesn't read `agent-*.jsonl` files.
- Pricing is hardcoded from LiteLLM's dataset (the same source ccusage uses); the script reconciles against ccusage at the end so any drift surfaces in every run. Expected drift is a few percent (subagent spend that ccusage misses); >20% trips a stale-rates warning.
- `scripts/test_claude_skill_attribution_unit.py` adds 38 unit tests mirroring the existing `test_claude_usage_report_unit.py` style (AAA, named consts, no magic numbers).

## Test plan

- [ ] `python scripts/test_claude_skill_attribution_unit.py` passes (38 tests)
- [ ] Live run: `python scripts/claude-skill-attribution.py --out-dir /tmp/x` produces a markdown report with the per-skill table populated and a sane reconcile line vs ccusage
- [ ] Reconcile drift sits in the expected single-digit-percent range on a 60-day window
- [ ] Markdown renders cleanly when previewed (per-skill table, main-vs-sidechain split, top-N turns)