### PR TITLE
Fix git config arg order in start-work email lookup

### DIFF
--- a/plugins/start-work/commands/start-work.md
+++ b/plugins/start-work/commands/start-work.md
@@ -93,7 +93,7 @@ GitHub has no formal state to transition — assignment is the active signal.
 ### ADO
 Use `mcp__azure-devops__wit_update_work_item` to:
 1. Set `System.State` to `Active`. Some teams use `In Progress` or another non-default state name — if the project's process template uses a non-`Active` next state, surface the choices and ask the user before guessing.
-2. Set `System.AssignedTo` to the current user. Source the user's email from `git config user.email` (run `git config user.email --get`) or from the email recorded in `~/.claude/CLAUDE.md`. Note: `mcp__azure-devops__core_list_project_teams` returns *teams*, not user identity — don't use it for this lookup.
+2. Set `System.AssignedTo` to the current user. Source the user's email from git config (run `git config --get user.email`) or from the email recorded in `~/.claude/CLAUDE.md`. Note: `mcp__azure-devops__core_list_project_teams` returns *teams*, not user identity — don't use it for this lookup.
 
 If the work item is already `Active` and assigned to the current user, this step is a no-op — log it and continue.
 


### PR DESCRIPTION
## Problem

The `start-work` skill's ADO assignee step (`plugins/start-work/commands/start-work.md`) instructed the model to run:

```
git config user.email --get
```

Git parses this as a **write** — it sets the local `user.email` key to the literal value `--get` — rather than reading the configured value. Running the skill silently clobbers the repo-local commit email, which then fails `.commit-email-rules` enforcement and mis-attributes commits.

## Fix

One-line change to the correct read form (flag before key):

```
git config --get user.email
```

Observed live: a `start-work` run set a repo's local `user.email` to `--get`; restoring it required `git config --local user.email <correct>`.