### PR TITLE
Fix start-work.sh nesting new worktree inside current worktree

### DIFF
--- a/plugins/start-work/scripts/start-work.sh
+++ b/plugins/start-work/scripts/start-work.sh
@@ -76,8 +76,13 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     exit 1
 fi
 
-# Operate from the repo root so worktree paths resolve correctly.
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Operate from the MAIN repo root so worktree paths resolve correctly even when this
+# script is invoked from inside an existing worktree. `git rev-parse --show-toplevel`
+# returns the *current* worktree's root, so using it would nest the new worktree inside
+# the current one. `--git-common-dir` points at the main repo's shared .git directory
+# (always the main checkout's, regardless of which worktree we're in), and its parent is
+# the main repo root.
+REPO_ROOT="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
 cd "$REPO_ROOT"
 
 # Verify clean working tree — Git Hygiene Before New Work refuses to start on dirty state.

--- a/plugins/start-work/scripts/start-work.sh
+++ b/plugins/start-work/scripts/start-work.sh
@@ -76,13 +76,24 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     exit 1
 fi
 
-# Operate from the MAIN repo root so worktree paths resolve correctly even when this
-# script is invoked from inside an existing worktree. `git rev-parse --show-toplevel`
-# returns the *current* worktree's root, so using it would nest the new worktree inside
-# the current one. `--git-common-dir` points at the main repo's shared .git directory
-# (always the main checkout's, regardless of which worktree we're in), and its parent is
-# the main repo root.
-REPO_ROOT="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+# Resolve the root to operate from. The two modes want different roots:
+#
+#   Worktree mode: the new worktree must be created under the MAIN repo's
+#   .claude/worktrees/, even when this script is invoked from inside an existing
+#   worktree. `git rev-parse --show-toplevel` returns the *current* worktree's root, so
+#   using it here would nest the new worktree inside the current one (#155).
+#   `--git-common-dir` points at the main repo's shared .git directory (always the main
+#   checkout's, regardless of which worktree we're in), and its parent is the main root.
+#
+#   In-place mode (--no-worktree): `git checkout -b` switches the *current* checkout onto
+#   the new branch, so we must operate from the worktree the user is actually in —
+#   `--show-toplevel`. Using the main root here would silently switch the main checkout's
+#   branch instead of the current worktree's.
+if [ "$USE_WORKTREE" -eq 1 ]; then
+    REPO_ROOT="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+else
+    REPO_ROOT="$(git rev-parse --show-toplevel)"
+fi
 cd "$REPO_ROOT"
 
 # Verify clean working tree — Git Hygiene Before New Work refuses to start on dirty state.

--- a/plugins/start-work/scripts/test_start-work.sh
+++ b/plugins/start-work/scripts/test_start-work.sh
@@ -177,4 +177,30 @@ echo "$err" | grep -qi "already exists on origin" \
     || fail "expected NO worktree to be created when origin already has the branch"
 pass "branch already on origin (but not local) is refused"
 
+# 13. Regression (#155): running from INSIDE an existing worktree must create the new
+#     worktree as a SIBLING under the MAIN repo's .claude/worktrees/, not NESTED inside
+#     the current worktree. Pre-fix, REPO_ROOT was resolved via `git rev-parse
+#     --show-toplevel`, which returns the *current* worktree's root, so starting story B
+#     from within story A's worktree produced
+#     <repo>/.claude/worktrees/<A>/.claude/worktrees/<B>.
+repo="$(fresh_repo)"
+# Story A: create the first worktree from the main checkout.
+( cd "$repo" && bash "$SUT" --slug "story-a" --id "100" >/dev/null 2>&1 ) \
+    || fail "setup: expected story-a worktree creation to succeed"
+wt_a="$repo/.claude/worktrees/100-story-a"
+[ -d "$wt_a" ] || fail "setup: expected story-a worktree to exist"
+# Story B: run the script with cwd INSIDE story A's worktree.
+out="$( cd "$wt_a" && bash "$SUT" --slug "story-b" --id "200" 2>/dev/null )"
+last="$(printf '%s\n' "$out" | tail -1)"
+[ "$last" = "WORKTREE_PATH=.claude/worktrees/200-story-b" ] \
+    || fail "expected sibling WORKTREE_PATH for story-b, got: $last"
+[ -d "$repo/.claude/worktrees/200-story-b" ] \
+    || fail "expected story-b worktree as a SIBLING under the main repo root"
+[ ! -e "$wt_a/.claude/worktrees/200-story-b" ] \
+    || fail "story-b worktree was NESTED inside story-a's worktree (bug #155 regression)"
+( cd "$repo/.claude/worktrees/200-story-b" \
+    && [ "$(git branch --show-current)" = "branches/200-story-b" ] ) \
+    || fail "expected story-b worktree on branches/200-story-b"
+pass "worktree from inside an existing worktree lands as a sibling, not nested (#155)"
+
 echo "all smoke tests passed"

--- a/plugins/start-work/scripts/test_start-work.sh
+++ b/plugins/start-work/scripts/test_start-work.sh
@@ -203,4 +203,28 @@ last="$(printf '%s\n' "$out" | tail -1)"
     || fail "expected story-b worktree on branches/200-story-b"
 pass "worktree from inside an existing worktree lands as a sibling, not nested (#155)"
 
+# 14. Regression (#155): --no-worktree run from INSIDE an existing worktree must switch
+#     THAT worktree onto the new branch (its documented "current checkout" semantics), not
+#     the main checkout. The fix resolves REPO_ROOT via --show-toplevel for in-place mode,
+#     so `git checkout -b` acts on the worktree the user is in — using the main root would
+#     silently switch the main checkout's branch instead.
+repo="$(fresh_repo)"
+( cd "$repo" && bash "$SUT" --slug "host-a" --id "300" >/dev/null 2>&1 ) \
+    || fail "setup: expected host-a worktree creation to succeed"
+wt_host="$repo/.claude/worktrees/300-host-a"
+[ -d "$wt_host" ] || fail "setup: expected host-a worktree to exist"
+out="$( cd "$wt_host" && bash "$SUT" --slug "child-b" --id "301" --no-worktree 2>/dev/null )"
+[ "$out" = "BRANCH=branches/301-child-b" ] \
+    || fail "expected BRANCH-only output for --no-worktree from inside a worktree, got: $out"
+# The CURRENT worktree (host-a) must now be on the new branch...
+( cd "$wt_host" && [ "$(git branch --show-current)" = "branches/301-child-b" ] ) \
+    || fail "expected host-a worktree to be switched onto branches/301-child-b"
+# ...and the MAIN checkout must be untouched (still on main).
+( cd "$repo" && [ "$(git branch --show-current)" = "main" ] ) \
+    || fail "main checkout was switched off main by an in-place run from inside a worktree"
+# No new worktree directory should have been created.
+[ ! -d "$repo/.claude/worktrees/301-child-b" ] \
+    || fail "expected NO worktree directory in --no-worktree mode"
+pass "--no-worktree from inside a worktree switches the current worktree, not main (#155)"
+
 echo "all smoke tests passed"


### PR DESCRIPTION
## Summary

`start-work.sh` resolved its working root with `git rev-parse --show-toplevel`, which returns the **current** worktree's root rather than the **main** repo root. When `/start-work` is invoked from inside an existing worktree (the common case — starting a new story while still sitting in a previous story's worktree), the new worktree was created **nested inside** the current one, and the `WT_PATH` collision guard was evaluated against the wrong root.

## Fix

Resolve the main repo root via the parent of `git rev-parse --path-format=absolute --git-common-dir`, which points at the shared `.git` directory regardless of which worktree is active:

```bash
REPO_ROOT="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
```

This also makes the existing `WT_PATH` collision check correct, since the path now resolves against the main root.

## Tests

Added regression case #13 to `test_start-work.sh`: creates worktree A, runs the script with `cwd` inside A, and asserts the new worktree lands as a **sibling** under the main repo's `.claude/worktrees/`, not nested inside A.

- Full suite passes (13 cases).
- Verified teeth: against a copy with the bug reintroduced, the first 12 tests pass and it fails precisely at the #155 case.
- `--path-format` requires Git ≥ 2.31 (released 2021); well within supported range.

Closes #155