### PR TITLE
Document context-hygiene habit: /clear before starting new work

### DIFF
--- a/plugins/start-work/commands/start-work.md
+++ b/plugins/start-work/commands/start-work.md
@@ -119,6 +119,7 @@ Present a single structured handoff message in this exact order:
 3. **Codebase research** — the punch list returned by Step 7, verbatim.
 4. **Draft plan** — 3-7 numbered steps proposing the implementation approach, grounded in the research. Each step is one short sentence. Explicitly call out non-obvious assumptions or open questions ("assumes the validator runs before the cache write — confirm").
 5. **Suggested next action** — typically: "Review the plan, then run Plan mode (or proceed directly) to start implementation."
+6. **Context-hygiene tip** — close with a single line: "Tip: next time, run `/clear` before `/start-work` — starting work rarely needs prior conversation history, and a clean context keeps the task focused." This reinforces the habit over repeated runs; the skill cannot clear context itself (it runs inside the context it would clear).
 
 Stop here. The deliverable is the prepared workspace + the draft plan. Do **not** begin implementation; the user reviews and decides how to proceed.
 

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -378,6 +378,8 @@ Before starting any new unit of work (picking up an issue, beginning a task that
 
 Do not start work on an existing feature branch unless the user explicitly asks to continue work on that branch.
 
+**Context hygiene:** Run `/clear` before starting a new unit of work (e.g., `/clear` then `/start-work`). Starting work almost never needs the prior conversation history, and a clean context keeps the new task focused and cheaper. Type the two prompts in succession — the clear is instant. Note this is a *user* habit, not something a skill can do for you: a skill runs inside the context it would clear, so it cannot reset its own history before executing (the "self-clearing paradox"). The harness has no hook or setting that clears context either (see issue #158).
+
 ## Branch Naming and PR Linking
 
 **Branch naming:** Create branches as `branches/<issue-number>-<kebab-case-slug>` (illustrative: `branches/305-duplicate-notifications-ios`). Include the issue or work-item number when one exists; when no tracked item exists, use `branches/<kebab-case-slug>` with no numeric prefix. If a branch resolves multiple issues, use the primary issue number in the branch name and list the rest in the PR body via additional `Closes #N` lines. Use only lowercase letters, numbers, and hyphens — compatible with both GitHub and Azure DevOps. Keep slugs under ~50 characters so they don't trip shell tab-completion or filename-length limits.

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -378,7 +378,7 @@ Before starting any new unit of work (picking up an issue, beginning a task that
 
 Do not start work on an existing feature branch unless the user explicitly asks to continue work on that branch.
 
-**Context hygiene:** Run `/clear` before starting a new unit of work (e.g., `/clear` then `/start-work`). Starting work almost never needs the prior conversation history, and a clean context keeps the new task focused and cheaper. Type the two prompts in succession — the clear is instant. Note this is a *user* habit, not something a skill can do for you: a skill runs inside the context it would clear, so it cannot reset its own history before executing (the "self-clearing paradox"). The harness has no hook or setting that clears context either (see issue #158).
+**Context hygiene:** Run `/clear` before starting a new unit of work (e.g., `/clear` then `/start-work`). Starting work almost never needs the prior conversation history, and a clean context keeps the new task focused and cheaper. Type the two prompts in succession — the clear is instant. Note this is a *user* habit, not something a skill can do for you: a skill runs inside the context it would clear, so it cannot reset its own history before executing (the "self-clearing paradox"). The harness has no hook or setting that clears context either.
 
 ## Branch Naming and PR Linking
 


### PR DESCRIPTION
## Summary

Establishes a team habit: run `/clear` before starting a new unit of work. Starting work almost never needs prior conversation history, so a clean context keeps the task focused and cheaper.

We investigated whether the harness could do this automatically (so there'd be no manual step) and confirmed it **cannot**: hooks can't clear context, there's no fresh-context frontmatter flag, no `/clear`-and-run chaining, and a skill can't clear the context it runs inside (the self-clearing paradox). Full findings are in #158.

## Changes

- **`standards/CLAUDE.md`** — adds a **Context hygiene** note under *Git Hygiene Before New Work*, parallel to the existing git-state hygiene rule.
- **`plugins/start-work/commands/start-work.md`** — adds a one-line context-hygiene tip to the hand-off, so the habit is reinforced over repeated runs.

## Notes

- Docs/standards only — no behavioral code change.
- The same tip likely belongs on `deep-review` and other token-heavy skills; tracked as a separate follow-up rather than expanding this PR's scope.

Closes #158