### PR TITLE
Fix git config GET footgun: enforce flag-before-key ordering

### DIFF
--- a/plugins/start-work/commands/start-work.md
+++ b/plugins/start-work/commands/start-work.md
@@ -93,7 +93,7 @@ GitHub has no formal state to transition — assignment is the active signal.
 ### ADO
 Use `mcp__azure-devops__wit_update_work_item` to:
 1. Set `System.State` to `Active`. Some teams use `In Progress` or another non-default state name — if the project's process template uses a non-`Active` next state, surface the choices and ask the user before guessing.
-2. Set `System.AssignedTo` to the current user. Source the user's email from `git config user.email` (run `git config user.email --get`) or from the email recorded in `~/.claude/CLAUDE.md`. Note: `mcp__azure-devops__core_list_project_teams` returns *teams*, not user identity — don't use it for this lookup.
+2. Set `System.AssignedTo` to the current user. Source the user's email by reading `git config --get user.email` — note the flag goes **before** the key; the reversed order silently *sets* the key instead of reading it. Or use the email recorded in `~/.claude/CLAUDE.md`. Note: `mcp__azure-devops__core_list_project_teams` returns *teams*, not user identity — don't use it for this lookup.
 
 If the work item is already `Active` and assigned to the current user, this step is a no-op — log it and continue.
 

--- a/scripts/test_no-git-config-get-footgun.sh
+++ b/scripts/test_no-git-config-get-footgun.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Regression guard for issue #157 — the `git config` GET footgun.
+#
+# Bug: placing a read flag AFTER the key (`git config user.email --get`)
+# makes git parse the flag as the VALUE and silently *set* the key to the
+# literal string `--get` (exit 0, no output). In a worktree this writes to
+# the shared common .git/config and corrupts the author identity for every
+# worktree of the repo. The safe form puts the flag first: `git config
+# --get user.email`.
+#
+# What this guards: scans all tracked files for the dangerous ordering
+# `git config <key> --get` and fails if any reappear. This is the only
+# testable surface — the fix itself is documentation/prompt-template text,
+# which the team Unit Test Standards exempt, but a grep guard is cheap
+# insurance against the pattern creeping back into a skill or script.
+#
+# Known limitation (no silent cap): the pattern allows leading dash-flags
+# before the key (e.g. `git config --global KEY --get` is caught) but does
+# not attempt to model every git-config invocation. It targets the simple,
+# recurring form our tooling actually uses.
+#
+# Allowlist: a line that intentionally *documents* the bad form (a teaching
+# counter-example) can opt out by including the marker `footgun-allow` on the
+# same line — e.g. an HTML comment in a markdown doc.
+#
+# Invoke: bash scripts/test_no-git-config-get-footgun.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SELF_REL="scripts/$(basename "$0")"
+
+# ERE for the dangerous ordering: `git config`, optional leading dash-flags,
+# then a key token that does NOT start with `-`, then a `--get*` read flag.
+# Matches `git config user.email --get`; does NOT match the safe
+# `git config --get user.email` (the token after `git config ` is a dash-flag).
+PATTERN='git config([[:space:]]+-[^[:space:]]+)*[[:space:]]+[^[:space:]-][^[:space:]]*[[:space:]]+--get'
+
+fail=0
+pass=0
+
+assert() {
+    local cond="$1" label="$2"
+    if [ "$cond" -eq 0 ]; then
+        pass=$((pass + 1)); echo "  PASS $label"
+    else
+        fail=$((fail + 1)); echo "  FAIL $label"
+    fi
+}
+
+echo "1) this guard parses as valid bash"
+if bash -n "$0"; then
+    pass=$((pass + 1)); echo "  PASS bash -n parses the guard"
+else
+    fail=$((fail + 1)); echo "  FAIL bash -n reported a syntax error"
+fi
+
+echo "2) regex sanity: dangerous form is detected"
+printf '%s\n' 'git config user.email --get' | grep -Eq "$PATTERN"
+assert $? "key-before-flag ordering matches the pattern"
+
+echo "3) regex sanity: leading flags before the key still caught"
+printf '%s\n' 'git config --global user.email --get' | grep -Eq "$PATTERN"
+assert $? "'--global KEY --get' matches the pattern"
+
+echo "4) regex sanity: safe form is NOT a false positive"
+if printf '%s\n' 'git config --get user.email' | grep -Eq "$PATTERN"; then
+    fail=$((fail + 1)); echo "  FAIL safe 'git config --get user.email' wrongly matched"
+else
+    pass=$((pass + 1)); echo "  PASS safe flag-before-key form is ignored"
+fi
+
+echo "5) regex sanity: plain set is NOT a false positive"
+if printf '%s\n' 'git config user.email "you@example.com"' | grep -Eq "$PATTERN"; then
+    fail=$((fail + 1)); echo "  FAIL plain set wrongly matched"
+else
+    pass=$((pass + 1)); echo "  PASS plain 'git config <key> <value>' is ignored"
+fi
+
+echo "6) repo scan: no tracked file uses the dangerous ordering"
+# git grep searches tracked files in the working tree. Exclude this guard,
+# which embeds the dangerous string as test fixtures above, and drop any line
+# carrying the `footgun-allow` marker (intentional teaching counter-examples).
+matches="$(cd "$REPO_ROOT" && git grep -nE "$PATTERN" -- ":!$SELF_REL" 2>/dev/null | grep -v 'footgun-allow')"
+if [ -z "$matches" ]; then
+    pass=$((pass + 1)); echo "  PASS no occurrences in tracked files"
+else
+    fail=$((fail + 1)); echo "  FAIL dangerous ordering found:"
+    printf '%s\n' "$matches" | sed 's/^/    /'
+fi
+
+echo ""
+echo "Passed: $pass  Failed: $fail"
+[ "$fail" -eq 0 ]

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -330,6 +330,19 @@ query {
 - **Never force push** (`--force`, `-f`, `--force-with-lease`) to any branch
 - **Always create new commits instead of amending** — amending requires force pushing to sync with the remote. When a pre-commit hook fails, fix the issue and create a new commit; do not `--amend` the previous one. Only amend if the user explicitly requests it and acknowledges the force push consequence.
 
+## Reading Git Config Safely
+
+When **reading** a git config value, always put the read flag *before* the key:
+
+- ✅ `git config --get user.email`
+- ❌ `git config user.email --get` <!-- footgun-allow: intentional counter-example -->
+
+The second form parses `--get` as the **value** and silently *sets* `user.email` to the literal string `--get` (exit 0, no output — so it looks like it worked). In a worktree this writes to the shared common `.git/config`, corrupting the author identity for **every** worktree of the repo. With a `.commit-email-rules` pre-commit hook in play, subsequent commits then fail or get misattributed to `--get`. The same ordering trap applies to `--get-all`, `--get-regexp`, and `--unset` — flag first, key second.
+
+**Recovery** — if `git var GIT_AUTHOR_IDENT` shows a bogus email (e.g. `--get`):
+1. Find where the bad value lives: `git config --show-origin --get user.email`
+2. Remove it: `git config --unset user.email` (repeat per scope if it was set at more than one level), then re-set the correct address: `git config user.email "you@example.com"`.
+
 ## Commit Email
 
 Each repository should use a consistent commit email that matches its hosting platform's identity:


### PR DESCRIPTION
## Summary

`git config <key> --get` parses `--get` as a **value** and silently *sets* the key to the literal string `--get` (exit 0, no output — looks like it worked). In a worktree this writes to the shared common `.git/config`, corrupting the author identity for **every** worktree of the repo, and breaks `.commit-email-rules` pre-commit checks. The `start-work` skill was teaching the dangerous form, so the bug recurred.

## Changes

- **`standards/CLAUDE.md`** — new "Reading Git Config Safely" section: the flag-before-key rule (✅ `git config --get user.email`) and recovery guidance (`git var GIT_AUTHOR_IDENT` → `--show-origin --get` → `--unset`/re-set).
- **`plugins/start-work/commands/start-work.md`** (Step 6) — corrected `git config user.email --get` to `git config --get user.email`.
- **`scripts/test_no-git-config-get-footgun.sh`** — regression guard that scans all tracked files for the dangerous ordering and fails if it reappears. Honors a `footgun-allow` marker so intentional teaching counter-examples (the ❌ example in the standard) don't trip it. 6/6 passing.

## Acceptance criteria

- [x] `standards/CLAUDE.md` gains the flag-before-key rule
- [x] Recovery guidance included
- [x] `start-work` Step 6 corrected
- [x] Grep of other skills/scripts — promoted from a one-time grep to a standing guard (only prior occurrence was the one fixed here)

Closes #157