### PR TITLE
Add C# accessibility & immutability rules to standards/CLAUDE.md

### DIFF
--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -33,8 +33,8 @@ standards, then have each developer re-run the sync script.
 - Prefix private fields with `_` and use camelCase (e.g., `_connectionString`, `_logger`)
 - **Use the most restrictive accessibility that satisfies the requirement** — don't reach for `public` by habit; widen a member's visibility only when a caller actually needs it
 - **Prefer immutable properties:** use `{ get; }` or `{ get; init; }` for values set at construction and not changed afterward; use `private set` when the type mutates the value internally; reserve `public set` for properties external callers must genuinely reassign
-- **Prefer `record` types for immutable data** — DTOs, value objects, and result/config models — for init-only properties and value equality. Keep `class` for types with identity or mutable state, and for EF Core entities (record value-equality conflicts with EF change tracking)
-- **Exception — serialization/binding types:** types materialized by a serializer, ORM, or model binder (System.Text.Json, EF Core, ASP.NET model binding) may expose whatever setters those frameworks require — don't fight the framework to satisfy these rules
+- **Prefer `record` types for immutable data** — DTOs, value objects, and result/config models — for init-only properties and value equality. Keep `class` for types with identity or mutable state — e.g. persistence/ORM entities, where value-equality semantics break change tracking
+- **Exception — serialization/binding types:** types materialized by a serializer, ORM, or model binder (System.Text.Json, ASP.NET model binding) may expose whatever setters those frameworks require — don't fight the framework to satisfy these rules
 
 ## Unit Test Standards
 

--- a/standards/CLAUDE.md
+++ b/standards/CLAUDE.md
@@ -31,6 +31,10 @@ standards, then have each developer re-run the sync script.
 - Always use explicit types instead of `var` unless the type is immediately obvious from the right side of the assignment
 - Use `string.Empty` instead of `""`
 - Prefix private fields with `_` and use camelCase (e.g., `_connectionString`, `_logger`)
+- **Use the most restrictive accessibility that satisfies the requirement** — don't reach for `public` by habit; widen a member's visibility only when a caller actually needs it
+- **Prefer immutable properties:** use `{ get; }` or `{ get; init; }` for values set at construction and not changed afterward; use `private set` when the type mutates the value internally; reserve `public set` for properties external callers must genuinely reassign
+- **Prefer `record` types for immutable data** — DTOs, value objects, and result/config models — for init-only properties and value equality. Keep `class` for types with identity or mutable state, and for EF Core entities (record value-equality conflicts with EF change tracking)
+- **Exception — serialization/binding types:** types materialized by a serializer, ORM, or model binder (System.Text.Json, EF Core, ASP.NET model binding) may expose whatever setters those frameworks require — don't fight the framework to satisfy these rules
 
 ## Unit Test Standards
 


### PR DESCRIPTION
## Summary

Adds four rules to the `### C#` section of `standards/CLAUDE.md`, addressing the observation in #145 that generated code defaults to `public` getters/setters when tighter accessibility / immutability would be better.

The underlying problem is **mutability**, not keywords — so the rules push immutable-by-default with the idiomatic C# tools, and name the exceptions that would otherwise cause framework friction.

## The four rules

1. **Most restrictive accessibility** that satisfies the requirement — don't default to `public`.
2. **Immutable properties:** `{ get; }` / `{ get; init; }` by default; `private set` for internal mutation; `public set` only when external reassignment is genuinely needed.
3. **Prefer `record` types for immutable data** (DTOs, value objects, result/config models); keep `class` for identity/mutable state and **EF Core entities** (record value-equality conflicts with EF change tracking).
4. **Exception — serialization/binding types:** types materialized by a serializer, ORM, or model binder may expose framework-required setters. Don't fight the framework.

## Scope decisions

- **Member/property level only** — deliberately *not* mandating type-level `internal`-by-default, which rarely helps app code and fights DI/test tooling.
- **Explicit DTO/EF carve-out** — an absolute rule that breaks serializers/ORMs would just get ignored; a principled default + named exceptions holds up.

The original card was terse; scope was worked out collaboratively (immutability focus + records + the serialization exception).

## Acceptance criteria

- [x] Rule(s) added to `standards/CLAUDE.md` (`### C#`)
- [x] Syncs into `~/.claude/CLAUDE.md` on next `setup-env` run (whole file is wrapped in the `TEAM-STANDARDS` markers)

Closes #145