### PR TITLE
Fix setup-env.ps1 settings-merge corruption (data loss)

### DIFF
--- a/.github/workflows/test-setup-env.yml
+++ b/.github/workflows/test-setup-env.yml
@@ -1,0 +1,21 @@
+name: test-setup-env
+
+# Guards against the settings-merge corruption regression (issue #201).
+on:
+  pull_request:
+    paths:
+      - "setup-env.ps1"
+      - "scripts/Merge-JsonObjects.ps1"
+      - "scripts/test-merge-jsonobjects.ps1"
+      - ".github/workflows/test-setup-env.yml"
+  push:
+    branches: [main]
+
+jobs:
+  merge-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Merge-JsonObjects regression test (pwsh)
+        shell: pwsh
+        run: ./scripts/test-merge-jsonobjects.ps1

--- a/.github/workflows/test-setup-env.yml
+++ b/.github/workflows/test-setup-env.yml
@@ -7,6 +7,8 @@ on:
       - "setup-env.ps1"
       - "scripts/Merge-JsonObjects.ps1"
       - "scripts/test-merge-jsonobjects.ps1"
+      - "scripts/test-setup-env-integration.ps1"
+      - "standards/settings.json"
       - ".github/workflows/test-setup-env.yml"
   push:
     branches: [main]
@@ -16,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Merge-JsonObjects regression test (pwsh)
+      - name: Merge-JsonObjects unit test (pwsh)
         shell: pwsh
         run: ./scripts/test-merge-jsonobjects.ps1
+      - name: Settings-sync integration test (pwsh)
+        shell: pwsh
+        run: ./scripts/test-setup-env-integration.ps1

--- a/scripts/Merge-JsonObjects.ps1
+++ b/scripts/Merge-JsonObjects.ps1
@@ -1,0 +1,57 @@
+# Deep-merge two objects parsed from JSON via ConvertFrom-Json.
+# Team settings are the base; user settings override. Objects merge key-by-key,
+# arrays are unioned (deduped), scalars take the override value.
+#
+# Dot-source this file to use Merge-JsonObjects with no side effects
+# (see scripts/test-merge-jsonobjects.ps1).
+#
+# CRITICAL: both `.Name` accesses are wrapped in @(). When an object has a
+# SINGLE property, PowerShell returns its `.Name` as a scalar string, not an
+# array — and `"permissions" + <names[]>` is then STRING concatenation, which
+# collapses every key into one space-joined garbage key and wipes the real
+# settings. standards/settings.json has exactly one top-level key
+# (`permissions`), so this hit every Windows sync. See issue #201.
+
+function Merge-JsonObjects {
+    param(
+        [Parameter(Mandatory)] $Base,
+        [Parameter(Mandatory)] $Override
+    )
+
+    if ($Base -is [System.Management.Automation.PSCustomObject] -and
+        $Override -is [System.Management.Automation.PSCustomObject]) {
+        $Result = [PSCustomObject]@{}
+        $AllKeys = @(@($Base.PSObject.Properties.Name) + @($Override.PSObject.Properties.Name) | Sort-Object -Unique)
+        foreach ($Key in $AllKeys) {
+            # A real settings key is a camelCase identifier and never contains
+            # whitespace. A whitespace key is the corruption signature from an
+            # earlier buggy sync — skip it so this run heals the file.
+            if ($Key -match '\s') {
+                Write-Warning "Skipping corrupted settings key (contains whitespace): '$Key'"
+                continue
+            }
+            $HasBase = $null -ne ($Base.PSObject.Properties | Where-Object { $_.Name -eq $Key })
+            $HasOverride = $null -ne ($Override.PSObject.Properties | Where-Object { $_.Name -eq $Key })
+            if ($HasBase -and $HasOverride) {
+                $Result | Add-Member -NotePropertyName $Key -NotePropertyValue (
+                    Merge-JsonObjects -Base $Base.$Key -Override $Override.$Key
+                )
+            }
+            elseif ($HasOverride) {
+                $Result | Add-Member -NotePropertyName $Key -NotePropertyValue $Override.$Key
+            }
+            else {
+                $Result | Add-Member -NotePropertyName $Key -NotePropertyValue $Base.$Key
+            }
+        }
+        return $Result
+    }
+    elseif ($Base -is [System.Collections.IEnumerable] -and $Base -isnot [string] -and
+            $Override -is [System.Collections.IEnumerable] -and $Override -isnot [string]) {
+        $Combined = @($Base) + @($Override) | Sort-Object -Unique
+        return @($Combined)
+    }
+    else {
+        return $Override
+    }
+}

--- a/scripts/Merge-JsonObjects.ps1
+++ b/scripts/Merge-JsonObjects.ps1
@@ -1,22 +1,31 @@
 # Deep-merge two objects parsed from JSON via ConvertFrom-Json.
 # Team settings are the base; user settings override. Objects merge key-by-key,
-# arrays are unioned (deduped), scalars take the override value.
+# arrays are unioned (order-preserving, case-sensitive dedup), scalars take the
+# override value.
 #
 # Dot-source this file to use Merge-JsonObjects with no side effects
-# (see scripts/test-merge-jsonobjects.ps1).
+# (see scripts/test-merge-jsonobjects.ps1 and scripts/test-setup-env-integration.ps1).
 #
-# CRITICAL: both `.Name` accesses are wrapped in @(). When an object has a
-# SINGLE property, PowerShell returns its `.Name` as a scalar string, not an
-# array — and `"permissions" + <names[]>` is then STRING concatenation, which
-# collapses every key into one space-joined garbage key and wipes the real
-# settings. standards/settings.json has exactly one top-level key
-# (`permissions`), so this hit every Windows sync. See issue #201.
+# Correctness notes (all verified on PowerShell 5.1 — see issue #201):
+#  - Both `.Name` accesses are wrapped in @(): a single-property object returns
+#    `.Name` as a SCALAR string, and `"permissions" + <names[]>` would then be
+#    STRING concatenation, collapsing every key into one garbage key.
+#  - Array results are returned with the unary comma operator (`,`): PowerShell
+#    unwraps a single-element array on `return`, which ConvertTo-Json then writes
+#    as a bare scalar — corrupting e.g. a one-rule `deny` into a string.
+#  - A `$null` value on either side is healed (not fatal): `[Parameter(Mandatory)]`
+#    would reject a null override (e.g. a corrupted `"permissions": null`) and
+#    abort the whole sync.
+#  - Union is case-SENSITIVE and order-preserving: `Sort-Object -Unique` is
+#    case-insensitive (drops case-distinct permission rules) and alphabetizes
+#    (destroys curated grouping and breaks the caller's idempotency check).
 
 function Merge-JsonObjects {
-    param(
-        [Parameter(Mandatory)] $Base,
-        [Parameter(Mandatory)] $Override
-    )
+    param($Base, $Override)
+
+    # Heal nulls toward the non-null side; a null override keeps the base value.
+    if ($null -eq $Override) { return $Base }
+    if ($null -eq $Base) { return $Override }
 
     if ($Base -is [System.Management.Automation.PSCustomObject] -and
         $Override -is [System.Management.Automation.PSCustomObject]) {
@@ -48,8 +57,17 @@ function Merge-JsonObjects {
     }
     elseif ($Base -is [System.Collections.IEnumerable] -and $Base -isnot [string] -and
             $Override -is [System.Collections.IEnumerable] -and $Override -isnot [string]) {
-        $Combined = @($Base) + @($Override) | Sort-Object -Unique
-        return @($Combined)
+        # Order-preserving, case-sensitive union: keep base items in order, then
+        # append override items not already present. (Settings arrays are string
+        # arrays; the dedup key is the item's string form.)
+        $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+        $list = [System.Collections.Generic.List[object]]::new()
+        foreach ($item in (@($Base) + @($Override))) {
+            if ($seen.Add([string]$item)) { $list.Add($item) }
+        }
+        # Unary comma prevents PowerShell from unwrapping a single-element array
+        # on return (which would serialize as a scalar and corrupt the schema).
+        return , $list.ToArray()
     }
     else {
         return $Override

--- a/scripts/test-merge-jsonobjects.ps1
+++ b/scripts/test-merge-jsonobjects.ps1
@@ -1,0 +1,45 @@
+# Regression tests for Merge-JsonObjects (issue #201). Run:
+#   powershell -File scripts/test-merge-jsonobjects.ps1
+# Exit 0 on pass, 1 on failure.
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'Merge-JsonObjects.ps1')
+
+$script:fail = 0
+function Assert($cond, $desc) {
+    if ($cond) { Write-Host "  ok: $desc" }
+    else { Write-Host "  FAIL: $desc"; $script:fail++ }
+}
+
+# Case 1 — THE #201 REGRESSION: a base with a single top-level key must not
+# collapse every key into one space-joined garbage key.
+$base = '{ "permissions": { "allow": ["a"] } }' | ConvertFrom-Json
+$over = '{ "permissions": { "allow": ["b"] }, "enabledPlugins": { "x": true }, "tui": "dark" }' | ConvertFrom-Json
+$m = Merge-JsonObjects -Base $base -Override $over
+$keys = @($m.PSObject.Properties.Name)
+Assert (@($keys | Where-Object { $_ -match '\s' }).Count -eq 0) "no whitespace/garbage key is produced"
+Assert (($keys -contains 'permissions') -and ($keys -contains 'enabledPlugins') -and ($keys -contains 'tui')) "all real top-level keys survive"
+Assert ((@($m.permissions.allow) -contains 'a') -and (@($m.permissions.allow) -contains 'b')) "permissions.allow is unioned (base + override)"
+Assert ($m.tui -eq 'dark') "scalar override value preserved"
+Assert ($m.enabledPlugins.x -eq $true) "nested override object preserved"
+
+# Case 2 — scalar override wins on conflict.
+$b2 = '{ "k": "base" }' | ConvertFrom-Json
+$o2 = '{ "k": "over" }' | ConvertFrom-Json
+Assert ((Merge-JsonObjects -Base $b2 -Override $o2).k -eq 'over') "override wins on scalar conflict"
+
+# Case 3 — arrays union and dedup.
+$b3 = '{ "a": ["x","y"] }' | ConvertFrom-Json
+$o3 = '{ "a": ["y","z"] }' | ConvertFrom-Json
+$m3 = @((Merge-JsonObjects -Base $b3 -Override $o3).a)
+Assert (($m3.Count -eq 3) -and ($m3 -contains 'x') -and ($m3 -contains 'z')) "arrays unioned and deduped"
+
+# Case 4 — a pre-corrupted whitespace key is dropped (auto-heal); clean keys survive.
+$b4 = '{ "permissions": { "allow": [] } }' | ConvertFrom-Json
+$o4 = '{ "a b c": null, "tui": "x" }' | ConvertFrom-Json
+$m4 = @((Merge-JsonObjects -Base $b4 -Override $o4 3>$null).PSObject.Properties.Name)
+Assert (-not ($m4 -contains 'a b c')) "pre-corrupted whitespace key is dropped"
+Assert ($m4 -contains 'tui') "clean keys survive the guard"
+
+Write-Host "---"
+if ($script:fail -gt 0) { Write-Host "FAILED: $script:fail test(s)"; exit 1 }
+Write-Host "OK: all Merge-JsonObjects tests pass"; exit 0

--- a/scripts/test-merge-jsonobjects.ps1
+++ b/scripts/test-merge-jsonobjects.ps1
@@ -40,6 +40,37 @@ $m4 = @((Merge-JsonObjects -Base $b4 -Override $o4 3>$null).PSObject.Properties.
 Assert (-not ($m4 -contains 'a b c')) "pre-corrupted whitespace key is dropped"
 Assert ($m4 -contains 'tui') "clean keys survive the guard"
 
+# Case 5 — a single-element merged array stays an array (regression: PowerShell
+# unwraps a 1-element array on return, which ConvertTo-Json writes as a scalar).
+$b5 = '{ "permissions": { "allow": [], "deny": [] } }' | ConvertFrom-Json
+$o5 = '{ "permissions": { "deny": ["only-one"] } }' | ConvertFrom-Json
+$deny = (Merge-JsonObjects -Base $b5 -Override $o5).permissions.deny
+Assert (($deny -is [array]) -and (@($deny).Count -eq 1)) "single-element merged array stays an array"
+
+# Case 6 — a null override on a shared key heals to base instead of crashing.
+$b6 = '{ "permissions": { "allow": ["keep"] } }' | ConvertFrom-Json
+$o6 = '{ "permissions": null }' | ConvertFrom-Json
+$m6 = Merge-JsonObjects -Base $b6 -Override $o6
+Assert (@($m6.permissions.allow) -contains 'keep') "null override heals to base (no crash)"
+
+# Case 7 — union is case-SENSITIVE (Claude Code matchers are case-sensitive).
+$b7 = '{ "a": ["Bash(git log:*)"] }' | ConvertFrom-Json
+$o7 = '{ "a": ["bash(GIT LOG:*)"] }' | ConvertFrom-Json
+Assert (@((Merge-JsonObjects -Base $b7 -Override $o7).a).Count -eq 2) "case-distinct entries are both kept"
+
+# Case 8 — union preserves order (base first, then new override entries) and dedups.
+$b8 = '{ "a": ["z","m"] }' | ConvertFrom-Json
+$o8 = '{ "a": ["m","new"] }' | ConvertFrom-Json
+$m8 = @((Merge-JsonObjects -Base $b8 -Override $o8).a)
+Assert (($m8.Count -eq 3) -and ($m8[0] -eq 'z') -and ($m8[-1] -eq 'new')) "union preserves order and dedups"
+
+# Case 9 — the @() fix holds at deeper single-key nesting.
+$b9 = '{ "a": { "b": { "c": ["x"] } } }' | ConvertFrom-Json
+$o9 = '{ "a": { "b": { "c": ["y"] } } }' | ConvertFrom-Json
+$m9 = Merge-JsonObjects -Base $b9 -Override $o9
+$m9keys = @($m9.PSObject.Properties.Name)
+Assert ((@($m9keys | Where-Object { $_ -match '\s' }).Count -eq 0) -and (@($m9.a.b.c) -contains 'x')) "no corruption at deep single-key nesting"
+
 Write-Host "---"
 if ($script:fail -gt 0) { Write-Host "FAILED: $script:fail test(s)"; exit 1 }
 Write-Host "OK: all Merge-JsonObjects tests pass"; exit 0

--- a/scripts/test-setup-env-integration.ps1
+++ b/scripts/test-setup-env-integration.ps1
@@ -1,0 +1,59 @@
+# Integration test for the settings-sync pipeline (issue #201). Mirrors
+# setup-env.ps1's read -> Merge-JsonObjects -> ConvertTo-Json -Depth 10 ->
+# Set-Content -> re-read against temp files, using the REAL team settings.json
+# (a single-top-level-key object — the corruption trigger). Guards the file
+# round-trip that the in-memory unit test can't reach. Run:
+#   pwsh scripts/test-setup-env-integration.ps1
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'Merge-JsonObjects.ps1')
+$RepoRoot = Split-Path $PSScriptRoot -Parent
+$SettingsSource = Join-Path (Join-Path $RepoRoot 'standards') 'settings.json'
+
+$script:fail = 0
+function Chk($cond, $d) { if ($cond) { Write-Host "  ok: $d" } else { Write-Host "  FAIL: $d"; $script:fail++ } }
+
+# Replicate setup-env.ps1's merge+write to a temp target; return the written text.
+function Invoke-Sync($userJson) {
+    $t = Join-Path ([System.IO.Path]::GetTempPath()) ("itest-" + [guid]::NewGuid().ToString('N') + ".json")
+    $userJson | Set-Content -Path $t -Encoding utf8
+    $team = Get-Content -Path $SettingsSource -Raw | ConvertFrom-Json
+    $existing = Get-Content -Path $t -Raw | ConvertFrom-Json
+    $merged = Merge-JsonObjects -Base $team -Override $existing 3>$null
+    $json = $merged | ConvertTo-Json -Depth 10
+    Set-Content -Path $t -Value $json -NoNewline -Encoding utf8
+    $raw = Get-Content -Path $t -Raw
+    Remove-Item -Force $t
+    return $raw
+}
+
+# 1. Realistically-corrupted user file: prior garbage key + a single-element deny
+#    + personal allow + scalar/plugin prefs.
+$raw = Invoke-Sync @'
+{
+  "permissions garbage key": null,
+  "permissions": { "allow": ["Bash(dotnet test *)"], "deny": ["Bash(rm -rf:*)"] },
+  "enabledPlugins": { "deep-review@tzander-skills": true },
+  "tui": "dark"
+}
+'@
+$back = $raw | ConvertFrom-Json
+Chk ($null -ne $back) "written file is valid JSON"
+Chk (@($back.PSObject.Properties.Name | Where-Object { $_ -match '\s' }).Count -eq 0) "no whitespace/garbage key in output"
+Chk ($back.permissions.allow.Count -ge 95) "team allow entries present (count=$($back.permissions.allow.Count))"
+Chk (@($back.permissions.allow) -contains 'Bash(dotnet test *)') "personal allow entry preserved (union)"
+Chk ($raw -match '"deny":\s*\[') "single-element deny stays an ARRAY (not collapsed to scalar)"
+Chk ($back.tui -eq 'dark') "scalar pref preserved"
+Chk ($back.enabledPlugins.'deep-review@tzander-skills' -eq $true) "enabledPlugins preserved"
+
+# 2. Idempotency: re-syncing an already-synced file is a no-op (no churn).
+$raw2 = Invoke-Sync $raw
+Chk ($raw2.Trim() -eq $raw.Trim()) "second sync is idempotent (no churn/reorder loop)"
+
+# 3. A null permissions value heals to the team allowlist instead of crashing.
+$raw3 = Invoke-Sync '{ "permissions": null, "tui": "x" }'
+$b3 = $raw3 | ConvertFrom-Json
+Chk ($b3.permissions.allow.Count -ge 95) "null permissions heals to the team allowlist (no crash)"
+
+Write-Host "---"
+if ($script:fail -gt 0) { Write-Host "INTEGRATION FAILED: $script:fail check(s)"; exit 1 }
+Write-Host "OK: full sync pipeline is correct, non-lossy, and idempotent"; exit 0

--- a/setup-env.ps1
+++ b/setup-env.ps1
@@ -177,42 +177,10 @@ Write-Host '=== Team Settings ==='
 $SettingsSource = Join-Path (Join-Path $RepoRoot 'standards') 'settings.json'
 $SettingsTarget = Join-Path $ClaudeDir 'settings.json'
 
-function Merge-JsonObjects {
-    param(
-        [Parameter(Mandatory)] $Base,
-        [Parameter(Mandatory)] $Override
-    )
-
-    if ($Base -is [System.Management.Automation.PSCustomObject] -and
-        $Override -is [System.Management.Automation.PSCustomObject]) {
-        $Result = [PSCustomObject]@{}
-        $AllKeys = @(($Base.PSObject.Properties.Name + $Override.PSObject.Properties.Name) | Sort-Object -Unique)
-        foreach ($Key in $AllKeys) {
-            $HasBase = $null -ne ($Base.PSObject.Properties | Where-Object { $_.Name -eq $Key })
-            $HasOverride = $null -ne ($Override.PSObject.Properties | Where-Object { $_.Name -eq $Key })
-            if ($HasBase -and $HasOverride) {
-                $Result | Add-Member -NotePropertyName $Key -NotePropertyValue (
-                    Merge-JsonObjects -Base $Base.$Key -Override $Override.$Key
-                )
-            }
-            elseif ($HasOverride) {
-                $Result | Add-Member -NotePropertyName $Key -NotePropertyValue $Override.$Key
-            }
-            else {
-                $Result | Add-Member -NotePropertyName $Key -NotePropertyValue $Base.$Key
-            }
-        }
-        return $Result
-    }
-    elseif ($Base -is [System.Collections.IEnumerable] -and $Base -isnot [string] -and
-            $Override -is [System.Collections.IEnumerable] -and $Override -isnot [string]) {
-        $Combined = @($Base) + @($Override) | Sort-Object -Unique
-        return @($Combined)
-    }
-    else {
-        return $Override
-    }
-}
+# Merge-JsonObjects lives in its own dot-sourceable script so it can be
+# unit-tested in isolation (scripts/test-merge-jsonobjects.ps1). See issue #201
+# for the single-key-base corruption this fixes.
+. (Join-Path (Join-Path $RepoRoot 'scripts') 'Merge-JsonObjects.ps1')
 
 if (-not (Test-Path $SettingsSource)) {
     Write-Host "No standards/settings.json found - skipping settings sync."

--- a/setup-env.ps1
+++ b/setup-env.ps1
@@ -177,11 +177,6 @@ Write-Host '=== Team Settings ==='
 $SettingsSource = Join-Path (Join-Path $RepoRoot 'standards') 'settings.json'
 $SettingsTarget = Join-Path $ClaudeDir 'settings.json'
 
-# Merge-JsonObjects lives in its own dot-sourceable script so it can be
-# unit-tested in isolation (scripts/test-merge-jsonobjects.ps1). See issue #201
-# for the single-key-base corruption this fixes.
-. (Join-Path (Join-Path $RepoRoot 'scripts') 'Merge-JsonObjects.ps1')
-
 if (-not (Test-Path $SettingsSource)) {
     Write-Host "No standards/settings.json found - skipping settings sync."
 }
@@ -193,6 +188,9 @@ else {
         Write-Host "Created $SettingsTarget with team settings."
     }
     else {
+        # Merge-JsonObjects lives in its own dot-sourceable script so it can be
+        # unit-tested in isolation (scripts/test-merge-jsonobjects.ps1). See #201.
+        . (Join-Path (Join-Path $RepoRoot 'scripts') 'Merge-JsonObjects.ps1')
         $ExistingSettings = Get-Content -Path $SettingsTarget -Raw | ConvertFrom-Json
         $Merged = Merge-JsonObjects -Base $TeamSettings -Override $ExistingSettings
         $MergedJson = $Merged | ConvertTo-Json -Depth 10
@@ -202,7 +200,7 @@ else {
             Write-Host "Settings in $SettingsTarget are already up to date."
         }
         else {
-            Set-Content -Path $SettingsTarget -Value $MergedJson -NoNewline
+            Set-Content -Path $SettingsTarget -Value $MergedJson -NoNewline -Encoding utf8
             Write-Host "Merged team settings into $SettingsTarget."
         }
     }


### PR DESCRIPTION
Fixes #201.

## Problem

`setup-env.ps1` destroys `~/.claude/settings.json` on every run: `Merge-JsonObjects` collapses all keys into a single null-valued key whose name is every setting name concatenated (`"permissionspermissions enabledPlugins tui …"`), wiping the `permissions` allowlist, most `enabledPlugins`, and scalar prefs. It **compounds each run** (`permissions` doubles). Hit live on a dev machine this week.

## Root cause

```powershell
# line 189 — no @() around the .Name accesses
$AllKeys = @(($Base.PSObject.Properties.Name + $Override.PSObject.Properties.Name) | Sort-Object -Unique)
```
`standards/settings.json` has a **single** top-level key (`permissions`), so `$Base.PSObject.Properties.Name` is a **scalar string**. PowerShell then evaluates `"permissions" + <names[]>` as **string concatenation** (array coerced to a space-joined string) instead of array union → one garbage key name → `Add-Member` creates it and the real keys are lost. The array-merge branch (line 209) already wraps operands in `@()`; this line didn't.

## Fix

- **Wrap both `.Name` accesses in `@()`** so the key collection is always array union, even for a single-property object.
- **Skip + warn on any whitespace-containing key** — impossible for a real settings key, so an already-corrupted file **self-heals** on the next sync.
- **Extract** `Merge-JsonObjects` into `scripts/Merge-JsonObjects.ps1` (dot-sourced by `setup-env.ps1`) so it's unit-testable without running the whole bootstrap.
- **Add `scripts/test-merge-jsonobjects.ps1`** — 9 assertions: the single-key-base regression, array union/dedup, scalar-override, nested merge, and the whitespace-key auto-heal.
- **CI** (`test-setup-env.yml`) runs the test under `pwsh`.

## Verification

- Test passes on the fix; **verified it fails on the old code** (the buggy version reproduces `"permissionspermissions enabledPlugins tui"`), so it's a real regression test, not vacuous.
- `setup-env.ps1` syntax-checked (not executed — it mutates global config).

## Note

`setup-env.sh` uses `jq` and **silently skips** the settings merge when `jq` is absent (as on the affected Windows/Git-Bash machine), so sync was broken both ways on Windows — the `.sh` no-ops, the `.ps1` corrupted. Flagged in #201 as a separate follow-up; not fixed here.

## Recovery for already-affected users

Reconstruct `~/.claude/settings.json` from `standards/settings.json` + personal `allow` entries + `enabledPlugins`/`extraKnownMarketplaces`. Scalar prefs (`tui`, `hooks`, …) whose values weren't captured are lost — reconfigure via `/config`. Don't run `setup-env.ps1` until this merges.