### PR TITLE
measure: model built-in read-only commands (fix residual over-count)

### DIFF
--- a/standards/allowlist_common.py
+++ b/standards/allowlist_common.py
@@ -18,6 +18,21 @@ SEP = re.compile(r"&&|\|\||;|\|&|\||&|\n")
 # the prefix match never inspects. Conservatively count these as prompting.
 RISKY = ("$(", "`", ">")
 
+# Commands Claude Code auto-approves as built-in read-only, needing no allow
+# rule (documented for v2.1.208+). Callers that want to model real auto-approval
+# (e.g. measure-allowlist-impact.py) pass this to bash_covered(); callers that
+# only care about the team allowlist (the validator, its tests) leave it empty.
+# Two documented caveats are handled in bash_covered(): `cd` into a directory
+# before `git` still prompts (the new dir's git hooks could run), and `find`
+# with -delete/-exec mutates.
+CLAUDE_BUILTIN_READONLY = frozenset({
+    "ls", "cat", "echo", "pwd", "head", "tail", "grep", "find",
+    "wc", "which", "diff", "stat", "du", "cd",
+})
+
+# find flags that make it mutate/execute (so it is no longer read-only).
+_FIND_MUTATES = re.compile(r"(?:^|\s)-(?:delete|exec|execdir|fprint\w*|ok)\b")
+
 
 def parse_bash_prefix(entry: str):
     """Return the command prefix inside a `Bash(<prefix>[:*| *])` allow entry.
@@ -35,12 +50,40 @@ def seg_matches(seg: str, prefixes) -> bool:
     return any(seg == p or seg.startswith(p + " ") for p in prefixes)
 
 
-def bash_covered(cmd: str, prefixes) -> bool:
-    """True only if EVERY segment of a compound command matches an allow prefix
-    (mirrors Claude Code: one unapproved segment prompts the whole line), and
-    the command contains no redirect/substitution that a prefix match can't vet.
+def _lead(seg: str) -> str:
+    """Leading command token of a segment (empty string if none)."""
+    parts = seg.split()
+    return parts[0] if parts else ""
+
+
+def bash_covered(cmd: str, prefixes, builtins=()) -> bool:
+    """True only if Claude Code would run `cmd` WITHOUT a permission prompt.
+
+    A compound command auto-approves only when EVERY segment is covered
+    (mirrors Claude Code: one unapproved segment prompts the whole line). Each
+    segment is covered when it matches an allow `prefix` or — when `builtins`
+    is supplied — leads with a built-in read-only command. Always prompts (not
+    covered) on:
+      - redirect/substitution the prefix match can't vet (RISKY),
+      - `cd <dir> && git ...`: running git in a new directory can execute that
+        directory's hooks, so Claude Code prompts regardless of allow rules,
+      - `find` with a mutating/executing flag (-delete/-exec/...).
     """
     if any(tok in cmd for tok in RISKY):
         return False
     segs = [s for s in SEP.split(cmd) if s.strip()]
-    return bool(segs) and all(seg_matches(s, prefixes) for s in segs)
+    if not segs:
+        return False
+    leads = [_lead(s) for s in segs]
+    if "cd" in leads and "git" in leads:
+        return False
+    for seg in segs:
+        if seg_matches(seg, prefixes):
+            continue
+        lead = _lead(seg)
+        if lead in builtins:
+            if lead == "find" and _FIND_MUTATES.search(seg):
+                return False
+            continue
+        return False
+    return True

--- a/standards/measure-allowlist-impact.py
+++ b/standards/measure-allowlist-impact.py
@@ -2,8 +2,12 @@
 """Measure how many tool calls the team allowlist auto-approves.
 
 Scans Claude Code transcripts and, for every Bash / MCP tool call, decides
-whether the *effective* allow rules would let it run WITHOUT a permission
-prompt. Use it to size the impact of the allowlist and to watch it over time.
+whether it would run WITHOUT a permission prompt. "Auto-approved" means the
+team allow rules cover it OR it is a Claude Code built-in read-only command
+(`ls`/`cat`/`grep`/`cd`/…, v2.1.208+) — the latter needs no allow rule, so
+counting it as "still prompting" would overstate the residual. The cd+git
+directory-hooks prompt and redirect/substitution are still counted as prompting
+(see allowlist_common.bash_covered).
 
 Caveat: transcripts do not record, per call, whether a prompt was actually
 shown (that depended on the settings state at the time, plus any per-project
@@ -29,7 +33,7 @@ import re
 from collections import Counter, defaultdict
 from pathlib import Path
 
-from allowlist_common import bash_covered, parse_bash_prefix
+from allowlist_common import CLAUDE_BUILTIN_READONLY, bash_covered, parse_bash_prefix
 
 REJECTION_MARKERS = ("doesn't want to proceed", "User rejected")
 
@@ -106,7 +110,7 @@ def main() -> int:
                         if not isinstance(cmd, str) or not cmd.strip():
                             continue
                         key = " ".join(cmd.strip().split()[:3])
-                        if bash_covered(cmd, bash_prefixes):
+                        if bash_covered(cmd, bash_prefixes, CLAUDE_BUILTIN_READONLY):
                             covered[key] += 1
                             covered_sessions[key].add(sid)
                         else:
@@ -123,7 +127,7 @@ def main() -> int:
     tot_cov = sum(covered.values())
     tot_prompt = sum(would_prompt.values())
     print(f"\n=== IMPACT ===")
-    print(f"tool calls AUTO-APPROVED by the allowlist (no prompt): {tot_cov}")
+    print(f"tool calls AUTO-APPROVED (allowlist + built-in read-only): {tot_cov}")
     print(f"tool calls that would STILL prompt:                    {tot_prompt}")
     print(f"hard rejection markers in window (prompt shown+declined): {rejections}")
 

--- a/standards/test-allowlist-common.py
+++ b/standards/test-allowlist-common.py
@@ -3,9 +3,10 @@
     python3 standards/test-allowlist-common.py
 Exit 0 on pass, 1 on failure.
 """
-from allowlist_common import bash_covered, parse_bash_prefix
+from allowlist_common import CLAUDE_BUILTIN_READONLY, bash_covered, parse_bash_prefix
 
 PREFIXES = ["git log", "git status", "gh pr view"]
+B = CLAUDE_BUILTIN_READONLY
 fails = []
 
 
@@ -32,8 +33,19 @@ check("redirect is risky", bash_covered("git log > /tmp/out", PREFIXES), False)
 check("append redirect is risky", bash_covered("git log >> /tmp/out", PREFIXES), False)
 check("command substitution is risky", bash_covered("git log $(rm x)", PREFIXES), False)
 check("backtick substitution is risky", bash_covered("git log `rm x`", PREFIXES), False)
-check("cd prefix not covered", bash_covered("cd /x && git log", PREFIXES), False)
+check("cd + git prompts (dir hooks), no builtins", bash_covered("cd /x && git log", PREFIXES), False)
 check("empty command", bash_covered("", PREFIXES), False)
+
+# --- built-in read-only modeling (the `builtins` param, for the measure tool) ---
+check("builtin ls auto-approves", bash_covered("ls -la", PREFIXES, B), True)
+check("builtin grep auto-approves", bash_covered("grep foo /etc/hosts", PREFIXES, B), True)
+check("cd + builtin auto-approves", bash_covered("cd /repo && grep foo x", PREFIXES, B), True)
+check("cd + git still prompts (dir hooks)", bash_covered("cd /repo && git status", PREFIXES, B), False)
+check("plain find auto-approves", bash_covered("find . -name '*.py'", PREFIXES, B), True)
+check("find -delete is not read-only", bash_covered("find . -name x -delete", PREFIXES, B), False)
+check("find -exec is not read-only", bash_covered("find . -type f -exec cat {} +", PREFIXES, B), False)
+check("builtin + uncovered still prompts", bash_covered("ls && dotnet build", PREFIXES, B), False)
+check("no builtins arg -> grep still prompts", bash_covered("grep foo x", PREFIXES), False)
 
 if fails:
     print(f"FAIL: {len(fails)} case(s)")


### PR DESCRIPTION
Part of #200 (the measurement-over-count item; the reframed issue stays open for the `git -C` angle).

## Problem

`measure-allowlist-impact.py` decided "would this prompt?" against **only the team allowlist**, ignoring Claude Code's **built-in read-only commands** (`ls`, `cat`, `echo`, `pwd`, `head`, `tail`, `grep`, `find`, `wc`, `which`, `diff`, `stat`, `du`, `cd` — auto-approved since **v2.1.208**). Those need no allow rule, so counting them as "still prompting" **inflated the residual**. This is what produced the misleading "~135/day from cd-prefixed compounds" figure while investigating #200 — most of it was built-ins that never prompt.

## Fix

Teach the shared matcher about the built-in set, with the two documented caveats so we don't swing to **under**-counting real prompts:

- `allowlist_common.bash_covered()` gains an optional `builtins` set — a segment is covered if it matches an allow prefix **or** leads with a built-in read-only command. Backward compatible (default empty ⇒ the validator and its tests are unchanged).
- **`cd <dir> && git …` still prompts** — running git in a new directory can execute that directory's hooks (Claude Code's security prompt), so this is *not* auto-approved regardless of allow rules.
- **`find` with `-delete`/`-exec`** is treated as mutating (not read-only).
- `measure-allowlist-impact.py` passes `CLAUDE_BUILTIN_READONLY`; the label now reads *"AUTO-APPROVED (allowlist + built-in read-only)"*.

## Tests

9 new cases in `test-allowlist-common.py` (already CI-covered): `ls`/`grep` auto-approve, `cd + builtin` auto-approves, `cd + git` still prompts, `find -delete`/`-exec` prompt, `builtin + uncovered` still prompts, and `no builtins arg ⇒ grep still prompts` (backward-compat). Validator + smoke tests unchanged and green.

## Effect

On the local transcript corpus, auto-approved **1,603 → 2,073**; the residual drops correspondingly, so future impact/residual numbers reflect reality instead of over-counting built-ins.